### PR TITLE
Add image source docker label so tools can generate changelog for images

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,8 @@
 FROM alpine:3.19
 
+# should probably be https://mau.dev/mautrix/meta but tooling can read scm data from gitlab.com and github.com
+LABEL org.opencontainers.image.source="https://github.com/mautrix/meta"
+
 ENV UID=1337 \
     GID=1337
 


### PR DESCRIPTION
Tools like renovate and dependabot depend on docker container labels to generate changelogs

Eg. https://docs.renovatebot.com/modules/datasource/docker/

Ideally org.opencontainers.image.revision should be injected as well, but I don't really know where the CI scripts are