### PR TITLE
Fix referer header for upload requests

### DIFF
--- a/messagix/client.go
+++ b/messagix/client.go
@@ -349,6 +349,10 @@ func (c *Client) getEndpoint(name string) string {
 	panic(fmt.Sprintf("messagix-client: endpoint %s not found", name))
 }
 
+func (c *Client) getEndpointForThreadID(threadID int64) string {
+	return c.getEndpoint("thread") + strconv.FormatInt(threadID, 10) + "/"
+}
+
 func (c *Client) IsAuthenticated() bool {
 	var isAuthenticated bool
 	if c.platform.IsMessenger() {

--- a/messagix/data/endpoints/facebook.go
+++ b/messagix/data/endpoints/facebook.go
@@ -17,6 +17,7 @@ func makeFacebookEndpoints(host string) map[string]string {
 		"base_url":       baseURL,
 		"login_page":     baseURL + "/login",
 		"messages":       baseURL + "/messages",
+		"thread":         baseURL + "/t/",
 		"cookie_consent": baseURL + "/cookie/consent/",
 		"graphql":        baseURL + "/api/graphql/",
 		"media_upload":   baseURL + "/ajax/mercury/upload.php?",

--- a/messagix/data/endpoints/instagram.go
+++ b/messagix/data/endpoints/instagram.go
@@ -12,6 +12,7 @@ var InstagramEndpoints = map[string]string{
 	"base_url":        instaBaseUrl, //+ "/",
 	"login_page":      instaBaseUrl + "/accounts/login/",
 	"messages":        instaBaseUrl + "/direct/inbox/",
+	"thread":          instaBaseUrl + "/direct/t/",
 	"graphql":         instaBaseUrl + "/api/graphql",
 	"cookie_consent":  "https://graphql.instagram.com/graphql/",
 	"default_graphql": "https://graphql.instagram.com/graphql/",

--- a/messagix/mercury.go
+++ b/messagix/mercury.go
@@ -29,7 +29,7 @@ type WaveformData struct {
 	SamplingFrequency int       `json:"sampling_frequency"`
 }
 
-func (c *Client) SendMercuryUploadRequest(ctx context.Context, media *MercuryUploadMedia) (*types.MercuryUploadResponse, error) {
+func (c *Client) SendMercuryUploadRequest(ctx context.Context, threadID int64, media *MercuryUploadMedia) (*types.MercuryUploadResponse, error) {
 	urlQueries := c.NewHttpQuery()
 	queryValues, err := query.Values(urlQueries)
 	if err != nil {
@@ -46,7 +46,7 @@ func (c *Client) SendMercuryUploadRequest(ctx context.Context, media *MercuryUpl
 	h.Set("accept", "*/*")
 	h.Set("content-type", contentType)
 	h.Set("origin", c.getEndpoint("base_url"))
-	h.Set("referer", c.getEndpoint("messages"))
+	h.Set("referer", c.getEndpointForThreadID(threadID))
 	h.Set("sec-fetch-dest", "empty")
 	h.Set("sec-fetch-mode", "cors")
 	h.Set("sec-fetch-site", "same-origin") // header is required

--- a/msgconv/from-matrix.go
+++ b/msgconv/from-matrix.go
@@ -133,6 +133,7 @@ func (mc *MessageConverter) downloadMatrixMedia(ctx context.Context, content *ev
 }
 
 func (mc *MessageConverter) reuploadFileToMeta(ctx context.Context, evt *event.Event, content *event.MessageEventContent) (*types.MercuryUploadResponse, error) {
+	threadID := mc.GetData(ctx).ThreadID
 	data, mimeType, fileName, err := mc.downloadMatrixMedia(ctx, content)
 	if err != nil {
 		return nil, err
@@ -146,7 +147,7 @@ func (mc *MessageConverter) reuploadFileToMeta(ctx context.Context, evt *event.E
 		mimeType = "audio/mp4"
 		fileName += ".m4a"
 	}
-	resp, err := mc.GetClient(ctx).SendMercuryUploadRequest(ctx, &messagix.MercuryUploadMedia{
+	resp, err := mc.GetClient(ctx).SendMercuryUploadRequest(ctx, threadID, &messagix.MercuryUploadMedia{
 		Filename:    fileName,
 		MimeType:    mimeType,
 		MediaData:   data,


### PR DESCRIPTION
Upload requests should pass `/direct/t/[threadID]` (IG) and `/t/[threadID]` (FB) as the referer header rather than `/direct/inbox` (IG) and `/messages` (FB) to mimic IG/FB web behavior.

This change could potentially help alleviate the "refresh error; please retry in a few minutes" when uploading files, in case there is any request flagging on the IG/FB side based on uncommon headers.

Tested by running the bridge locally and sending some attachments.