### PR TITLE
Fix message replies in e2e threads

### DIFF
--- a/msgconv/to-whatsapp.go
+++ b/msgconv/to-whatsapp.go
@@ -101,8 +101,7 @@ func (mc *MessageConverter) ToWhatsApp(
 	var meta waMsgApplication.MessageApplication_Metadata
 	if replyTo := mc.GetMetaReply(ctx, content); replyTo != nil {
 		meta.QuotedMessage = &waMsgApplication.MessageApplication_Metadata_QuotedMessage{
-			StanzaID:  replyTo.ReplyMessageId,
-			RemoteJID: mc.GetData(ctx).JID().String(),
+			StanzaID: replyTo.ReplyMessageId,
 			// TODO: this is hacky since it hardcodes the server
 			// TODO 2: should this be included for DMs?
 			Participant: types.JID{User: strconv.FormatInt(replyTo.ReplySender, 10), Server: types.MessengerServer}.String(),


### PR DESCRIPTION
In an e2e encrypted conversation/thread, message replies sent through the bridge were not rendered in Messenger web/desktop (while they were rendered in the Messenger mobile app).

Debugging the service worker for messenger.com, we can compare an incoming reply message sent from the official Messenger web client (left) to one sent from mautrix/meta bridge (right):

![Untitled 2](https://github.com/mautrix/meta/assets/855995/5898209b-7335-4323-9612-6597554e78e1)

From this, we can infer that `quotedMessage.remoteJid` is not needed (which, btw, used to have the same value as `quotedMessage.participant`).