### PR TITLE
Add periodic refresh for connection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 		Proxy                           string     `yaml:"proxy"`
 		GetProxyFrom                    string     `yaml:"get_proxy_from"`
 		MinFullReconnectIntervalSeconds int        `yaml:"min_full_reconnect_interval_seconds"`
+		ForceRefreshIntervalSeconds     int        `yaml:"force_refresh_interval_seconds"`
 	} `yaml:"meta"`
 
 	Bridge BridgeConfig `yaml:"bridge"`

--- a/config/config.go
+++ b/config/config.go
@@ -46,10 +46,11 @@ type Config struct {
 	*bridgeconfig.BaseConfig `yaml:",inline"`
 
 	Meta struct {
-		Mode         BridgeMode `yaml:"mode"`
-		IGE2EE       bool       `yaml:"ig_e2ee"`
-		Proxy        string     `yaml:"proxy"`
-		GetProxyFrom string     `yaml:"get_proxy_from"`
+		Mode                   BridgeMode `yaml:"mode"`
+		IGE2EE                 bool       `yaml:"ig_e2ee"`
+		Proxy                  string     `yaml:"proxy"`
+		GetProxyFrom           string     `yaml:"get_proxy_from"`
+		RefreshIntervalSeconds uint64     `yaml:"refresh_interval_seconds"`
 	} `yaml:"meta"`
 
 	Bridge BridgeConfig `yaml:"bridge"`

--- a/config/config.go
+++ b/config/config.go
@@ -46,11 +46,11 @@ type Config struct {
 	*bridgeconfig.BaseConfig `yaml:",inline"`
 
 	Meta struct {
-		Mode                   BridgeMode `yaml:"mode"`
-		IGE2EE                 bool       `yaml:"ig_e2ee"`
-		Proxy                  string     `yaml:"proxy"`
-		GetProxyFrom           string     `yaml:"get_proxy_from"`
-		RefreshIntervalSeconds uint64     `yaml:"refresh_interval_seconds"`
+		Mode                            BridgeMode `yaml:"mode"`
+		IGE2EE                          bool       `yaml:"ig_e2ee"`
+		Proxy                           string     `yaml:"proxy"`
+		GetProxyFrom                    string     `yaml:"get_proxy_from"`
+		MinFullReconnectIntervalSeconds int        `yaml:"min_full_reconnect_interval_seconds"`
 	} `yaml:"meta"`
 
 	Bridge BridgeConfig `yaml:"bridge"`

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -95,8 +95,8 @@ meta:
     # HTTP endpoint to request new proxy address from, for dynamically assigned proxies.
     # The endpoint must return a JSON body with a string field called proxy_url.
     get_proxy_from:
-    # Interval to force refresh the connection (disconnect and re-connect), default is 5 minutes. Set 0 to disable refreshes.
-    refresh_interval_seconds: 300
+    # Interval to force refresh the connection (disconnect and re-connect), default is 1 day. Set 0 to disable refreshes.
+    refresh_interval_seconds: 86400
 
 # Bridge config
 bridge:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -95,10 +95,10 @@ meta:
     # HTTP endpoint to request new proxy address from, for dynamically assigned proxies.
     # The endpoint must return a JSON body with a string field called proxy_url.
     get_proxy_from:
-    # Interval to force refresh the connection (disconnect and re-connect), default is 1 day. Set 0 to disable refreshes.
-    refresh_interval_seconds: 86400
-    # Minimum interval between full reconnects in seconds
-    min_full_reconnect_interval_seconds: 1
+    # Minimum interval between full reconnects in seconds, default is 1 hour
+    min_full_reconnect_interval_seconds: 3600
+    # Interval to force refresh the connection (full reconnect), default is 1 day. Set 0 to disable force refreshes.
+    force_refresh_interval_seconds: 86400
 
 # Bridge config
 bridge:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -95,6 +95,8 @@ meta:
     # HTTP endpoint to request new proxy address from, for dynamically assigned proxies.
     # The endpoint must return a JSON body with a string field called proxy_url.
     get_proxy_from:
+    # Interval to force refresh the connection (disconnect and re-connect), default is 5 minutes. Set 0 to disable refreshes.
+    refresh_interval_seconds: 300
 
 # Bridge config
 bridge:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -97,6 +97,8 @@ meta:
     get_proxy_from:
     # Interval to force refresh the connection (disconnect and re-connect), default is 1 day. Set 0 to disable refreshes.
     refresh_interval_seconds: 86400
+    # Minimum interval between full reconnects in seconds
+    min_full_reconnect_interval_seconds: 1
 
 # Bridge config
 bridge:

--- a/messagix/client.go
+++ b/messagix/client.go
@@ -263,7 +263,6 @@ func (c *Client) Disconnect() {
 		(*fn)()
 	}
 	c.socket.Disconnect()
-	c.socket.conn = nil
 }
 
 func (c *Client) SaveSession(path string) error {

--- a/messagix/client.go
+++ b/messagix/client.go
@@ -74,7 +74,7 @@ type Client struct {
 	stopCurrentConnection atomic.Pointer[context.CancelFunc]
 }
 
-func NewClient(cookies *cookies.Cookies, logger zerolog.Logger, refreshIntervalSeconds uint64) *Client {
+func NewClient(cookies *cookies.Cookies, logger zerolog.Logger) *Client {
 	if cookies.Platform == types.Unset {
 		panic("messagix: platform must be set in cookies")
 	}
@@ -106,11 +106,6 @@ func NewClient(cookies *cookies.Cookies, logger zerolog.Logger, refreshIntervalS
 		CsrBitmap:          crypto.NewBitmap(),
 	}
 	cli.socket = cli.newSocketClient()
-
-	logger.Debug().Uint64("refresh_interval_seconds", refreshIntervalSeconds).Msg("Setting refresh interval")
-	if refreshIntervalSeconds > 0 {
-		go cli.refreshConnectionPeriodically(time.Duration(refreshIntervalSeconds) * time.Second)
-	}
 
 	return cli
 }
@@ -393,17 +388,4 @@ func (c *Client) GetTaskId() int {
 
 	c.activeTasks = append(c.activeTasks, id)
 	return id
-}
-
-func (c *Client) refreshConnectionPeriodically(interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for range ticker.C {
-		c.Logger.Info().Msg("Refreshing connection")
-		c.Disconnect()
-		err := c.Connect()
-		if err != nil {
-			c.Logger.Err(err).Msg("Error refreshing connection")
-		}
-	}
 }

--- a/portal.go
+++ b/portal.go
@@ -609,7 +609,7 @@ func (portal *Portal) handleMatrixMessage(ctx context.Context, sender *User, evt
 	} else {
 		ctx = context.WithValue(ctx, msgconvContextKeyClient, sender.Client)
 		tasks, otid, err = portal.MsgConv.ToMeta(ctx, evt, content, relaybotFormatted)
-		if errors.Is(err, metaTypes.ErrPleaseReloadPage) && time.Since(sender.lastFullReconnect) > MinFullReconnectInterval {
+		if errors.Is(err, metaTypes.ErrPleaseReloadPage) && sender.canReconnect() {
 			log.Err(err).Msg("Got please reload page error while converting message, reloading page in background")
 			go sender.FullReconnect()
 			err = errReloading

--- a/user.go
+++ b/user.go
@@ -546,8 +546,8 @@ func (user *User) unlockedConnect() {
 
 	refreshInterval := time.Duration(user.bridge.Config.Meta.ForceRefreshIntervalSeconds) * time.Second
 	if refreshInterval > 0 {
-		user.log.Debug().Msgf("Connection will be refreshed at %s", time.Now().Add(refreshInterval).Format(time.RFC3339))
 		go func() {
+			user.log.Debug().Time("next_refresh", time.Now().Add(refreshInterval)).Msg("Setting force refresh timer")
 			user.forceRefreshTimer = time.NewTimer(refreshInterval)
 
 			<-user.forceRefreshTimer.C

--- a/user.go
+++ b/user.go
@@ -540,6 +540,7 @@ func (user *User) unlockedConnect() {
 			})
 		}
 		go user.sendMarkdownBridgeAlert(context.TODO(), "Failed to connect to %s: %v", user.bridge.ProtocolName, err)
+		return
 	}
 
 	refreshInterval := time.Duration(user.bridge.Config.Meta.ForceRefreshIntervalSeconds) * time.Second

--- a/user.go
+++ b/user.go
@@ -602,7 +602,7 @@ func (user *User) unlockedConnectWithCookies(cookies *cookies.Cookies) error {
 	log := user.log.With().Str("component", "messagix").Logger()
 	user.log.Debug().Msg("Connecting to Meta")
 	// TODO set proxy for media client?
-	cli := messagix.NewClient(cookies, log)
+	cli := messagix.NewClient(cookies, log, user.bridge.Config.Meta.RefreshIntervalSeconds)
 	if user.bridge.Config.Meta.GetProxyFrom != "" || user.bridge.Config.Meta.Proxy != "" {
 		cli.GetNewProxy = user.getProxy
 		if !cli.UpdateProxy("connect") {

--- a/user.go
+++ b/user.go
@@ -1166,7 +1166,9 @@ func (user *User) eventHandler(rawEvt any) {
 		user.BridgeState.Send(user.metaState)
 		go user.sendMarkdownBridgeAlert(context.TODO(), "Error in %s connection: %v", user.bridge.ProtocolName, evt.Err)
 		user.StopBackfillLoop()
-		user.forceRefreshTimer.Stop()
+		if user.forceRefreshTimer != nil {
+			user.forceRefreshTimer.Stop()
+		}
 	default:
 		user.log.Warn().Type("event_type", evt).Msg("Unrecognized event type from messagix")
 	}


### PR DESCRIPTION
We've observed a number of intermittent errors where the socket connection is closed while trying to send a message (`failed to send LS request: not connected`).

Until we figure out why that's happening, this should help mitigate those problems by refreshing the connection at a given interval.