### PR TITLE
Improve sending messages while reconnecting

### DIFF
--- a/messagix/client.go
+++ b/messagix/client.go
@@ -411,7 +411,7 @@ func (c *Client) WaitUntilCanSendMessages(timeout time.Duration) error {
 	for !c.canSendMessages {
 		select {
 		case <-timer.C:
-			return fmt.Errorf("timeout waiting for sending messages")
+			return fmt.Errorf("timeout waiting for canSendMessages")
 		default:
 			c.sendMessagesCond.Wait()
 		}

--- a/messagix/client.go
+++ b/messagix/client.go
@@ -73,8 +73,8 @@ type Client struct {
 
 	stopCurrentConnection atomic.Pointer[context.CancelFunc]
 
-	CanSendMessages  bool
-	SendMessagesCond *sync.Cond
+	canSendMessages  bool
+	sendMessagesCond *sync.Cond
 }
 
 func NewClient(cookies *cookies.Cookies, logger zerolog.Logger) *Client {
@@ -98,8 +98,8 @@ func NewClient(cookies *cookies.Cookies, logger zerolog.Logger) *Client {
 		platform:         cookies.Platform,
 		activeTasks:      make([]int, 0),
 		taskMutex:        &sync.Mutex{},
-		CanSendMessages:  false,
-		SendMessagesCond: sync.NewCond(&sync.Mutex{}),
+		canSendMessages:  false,
+		sendMessagesCond: sync.NewCond(&sync.Mutex{}),
 	}
 	cli.http.CheckRedirect = cli.checkHTTPRedirect
 
@@ -392,4 +392,29 @@ func (c *Client) GetTaskId() int {
 
 	c.activeTasks = append(c.activeTasks, id)
 	return id
+}
+
+func (c *Client) EnableSendingMessages() {
+	c.sendMessagesCond.L.Lock()
+	c.canSendMessages = true
+	c.sendMessagesCond.Broadcast()
+	c.sendMessagesCond.L.Unlock()
+}
+
+func (c *Client) WaitUntilCanSendMessages(timeout time.Duration) error {
+	c.sendMessagesCond.L.Lock()
+	defer c.sendMessagesCond.L.Unlock()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for !c.canSendMessages {
+		select {
+		case <-timer.C:
+			return fmt.Errorf("timeout waiting for sending messages")
+		default:
+			c.sendMessagesCond.Wait()
+		}
+	}
+	return nil
 }

--- a/messagix/client.go
+++ b/messagix/client.go
@@ -225,9 +225,9 @@ func (c *Client) Connect() error {
 		connectionAttempts := 1
 		reconnectIn := 2 * time.Second
 		for {
-			c.disableSendingMessages() // In case we're reconnecting from a normal network error
 			connectStart := time.Now()
 			err := c.socket.Connect()
+			c.disableSendingMessages()
 			if ctx.Err() != nil {
 				return
 			}

--- a/messagix/events.go
+++ b/messagix/events.go
@@ -109,6 +109,12 @@ func (s *Socket) handleReadyEvent(data *Event_Ready) error {
 	data.client = s.client
 	s.client.eventHandler(data.Finish())
 	s.previouslyConnected = true
+
+	s.client.SendMessagesCond.L.Lock()
+	s.client.CanSendMessages = true
+	s.client.SendMessagesCond.Signal()
+	s.client.SendMessagesCond.L.Unlock()
+
 	return nil
 }
 

--- a/messagix/events.go
+++ b/messagix/events.go
@@ -110,10 +110,7 @@ func (s *Socket) handleReadyEvent(data *Event_Ready) error {
 	s.client.eventHandler(data.Finish())
 	s.previouslyConnected = true
 
-	s.client.SendMessagesCond.L.Lock()
-	s.client.CanSendMessages = true
-	s.client.SendMessagesCond.Signal()
-	s.client.SendMessagesCond.L.Unlock()
+	s.client.EnableSendingMessages()
 
 	return nil
 }

--- a/portal.go
+++ b/portal.go
@@ -656,7 +656,10 @@ func (portal *Portal) handleMatrixMessage(ctx context.Context, sender *User, evt
 
 		retries := 0
 		for retries < MaxMetaSendAttempts {
-			sender.Client.WaitUntilCanSendMessages(15 * time.Second)
+			if err := sender.Client.WaitUntilCanSendMessages(15 * time.Second); err != nil {
+				log.Err(err).Msg("Error waiting to be able to send messages")
+				break
+			}
 			resp, err = sender.Client.ExecuteTasks(tasks...)
 			if err == nil {
 				break

--- a/portal.go
+++ b/portal.go
@@ -630,6 +630,12 @@ func (portal *Portal) handleMatrixMessage(ctx context.Context, sender *User, evt
 	timings.convert = time.Since(start)
 	start = time.Now()
 
+	sender.Client.SendMessagesCond.L.Lock()
+	for !sender.Client.CanSendMessages {
+		sender.Client.SendMessagesCond.Wait()
+	}
+	sender.Client.SendMessagesCond.L.Unlock()
+
 	if waMsg != nil {
 		messageID := sender.E2EEClient.GenerateMessageID()
 		log.UpdateContext(func(c zerolog.Context) zerolog.Context {

--- a/portal.go
+++ b/portal.go
@@ -630,12 +630,6 @@ func (portal *Portal) handleMatrixMessage(ctx context.Context, sender *User, evt
 	timings.convert = time.Since(start)
 	start = time.Now()
 
-	sender.Client.SendMessagesCond.L.Lock()
-	for !sender.Client.CanSendMessages {
-		sender.Client.SendMessagesCond.Wait()
-	}
-	sender.Client.SendMessagesCond.L.Unlock()
-
 	if waMsg != nil {
 		messageID := sender.E2EEClient.GenerateMessageID()
 		log.UpdateContext(func(c zerolog.Context) zerolog.Context {
@@ -657,6 +651,9 @@ func (portal *Portal) handleMatrixMessage(ctx context.Context, sender *User, evt
 		portal.pendingMessages[otid] = evt.ID
 		messageTS := time.Now()
 		var resp *table.LSTable
+
+		sender.Client.WaitForSendingMessages()
+
 		resp, err = sender.Client.ExecuteTasks(tasks...)
 		log.Trace().Any("response", resp).Msg("Meta send response")
 		var msgID string


### PR DESCRIPTION
# Context

Now that #58 has been merged, the connection will be refreshed (reconnected) periodically. The challenge now is to ensure that messages sent by the user during the reconnection are not lost but are properly delivered to the recipient.

To better illustrate the problem here are are some diagrams:

<img width="1222" alt="image" src="https://github.com/mautrix/meta/assets/855995/44ff4f7f-94d3-4e66-b9ab-ced71f051d8b">
<img width="952" alt="image" src="https://github.com/mautrix/meta/assets/855995/2a012275-ab1b-45af-8688-2b78ec8c38a8">

Colored in red are the changes we want to make to the current implementation.

# Description

This PR adds a `CanSendMessages` boolean flag to the `Client` struct, accompanied by a `SendMessagesCond` ([sync.Cond](https://pkg.go.dev/sync#Cond)).

Once the initial bootstrapping after a new connection is established is completed, we receive an `Event_Ready`. There we set the new `CanSendMessages` flag, and notify the change using `SendMessagesCond.Signal()`.

Before we send any new message to Meta, in `handleMatrixMessage`, we make sure to wait for the flag to be true using `SendMessagesCond.Wait()`. This way, `handleMatrixMessage` will be blocked while the reconnection is happening, effectively resuming once we're ready to send the messages.

Finally, note that setting `CanSendMessages` to false when disconnecting is not needed because the `Client` object is already [disposed](https://github.com/mautrix/meta/blob/6acd8d2a1c8d79c5a22b48f068282b402209e745/user.go#L1194)  (set to nil) on `unlockedDisconnect`.

This approach seemed simpler than adding a message queue or a more sophisticated retry mechanism for failed sent messages.