### PR TITLE
Reduce `force_refresh_interval_seconds` to 20 hours

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -97,8 +97,8 @@ meta:
     get_proxy_from:
     # Minimum interval between full reconnects in seconds, default is 1 hour
     min_full_reconnect_interval_seconds: 3600
-    # Interval to force refresh the connection (full reconnect), default is 1 day. Set 0 to disable force refreshes.
-    force_refresh_interval_seconds: 86400
+    # Interval to force refresh the connection (full reconnect), default is 20 hours. Set 0 to disable force refreshes.
+    force_refresh_interval_seconds: 72000
 
 # Bridge config
 bridge:


### PR DESCRIPTION
We suspect that CAT (crypto auth tokens) issued by Meta to connect to WhatsApp servers expire in 24 hours, which would cause a race condition with the current 24 hours force refresh interval. Reducing it to 20 hours should avoid this issue.