### PR TITLE
Fixes WhatsApp socket (e2e chats) reconnection on 401

### DIFF
--- a/user.go
+++ b/user.go
@@ -1040,8 +1040,9 @@ func (user *User) e2eeEventHandler(rawEvt any) {
 		user.BridgeState.Send(user.waState)
 		go user.sendMarkdownBridgeAlert(context.TODO(), "Error in WhatsApp connection: %s", evt.PermanentDisconnectDescription())
 	case events.PermanentDisconnect:
-		cf, ok := evt.(*events.ConnectFailure)
+		cf, ok := evt.(*events.LoggedOut)
 		if ok && cf.Reason == events.ConnectFailureLoggedOut && user.canReconnect() {
+			user.WADevice = nil
 			user.log.Debug().Msg("Doing full reconnect after WhatsApp 401 error")
 			go user.FullReconnect()
 		}

--- a/user.go
+++ b/user.go
@@ -1041,7 +1041,7 @@ func (user *User) e2eeEventHandler(rawEvt any) {
 		go user.sendMarkdownBridgeAlert(context.TODO(), "Error in WhatsApp connection: %s", evt.PermanentDisconnectDescription())
 	case events.PermanentDisconnect:
 		cf, ok := evt.(*events.LoggedOut)
-		if ok && cf.Reason == events.ConnectFailureLoggedOut && user.canReconnect() {
+		if ok && cf.Reason == events.ConnectFailureLoggedOut && !cf.OnConnect && user.canReconnect() {
 			user.WADevice = nil
 			user.log.Debug().Msg("Doing full reconnect after WhatsApp 401 error")
 			go user.FullReconnect()


### PR DESCRIPTION
When a user [log outs the device from the Messenger mobile app](https://www.facebook.com/help/messenger-app/986015482240175/?cms_platform=android-app&helpref=platform_switcher) for e2e chats, whatsmeow dispatches a `events.LoggedOut` event rather than a `events.ConnectFailure`:

```go
case code == "401" && conflictType == "device_removed":
	cli.expectDisconnect()
	cli.Log.Infof("Got device removed stream error, sending LoggedOut event and deleting session")
	go cli.dispatchEvent(&events.LoggedOut{OnConnect: false, Reason: events.ConnectFailureLoggedOut})
        //...
```
https://github.com/tulir/whatsmeow/blob/main/connectionevents.go#L34-L37

This PR fixes that, so even if the device is removed for e2e chats, we keep the bridge connected to the WA socket.