### PR TITLE
legacyprovision: fix RespError json serialization

### DIFF
--- a/cmd/mautrix-meta/legacyprovision.go
+++ b/cmd/mautrix-meta/legacyprovision.go
@@ -67,7 +67,7 @@ func legacyProvLogin(w http.ResponseWriter, r *http.Request) {
 		zerolog.Ctx(ctx).Err(err).Msg("Failed to log in")
 		var respErr bridgev2.RespError
 		if errors.As(err, &respErr) {
-			jsonResponse(w, respErr.StatusCode, &respErr)
+			respErr.Write(w)
 		} else {
 			jsonResponse(w, http.StatusInternalServerError, Error{ErrCode: "M_UNKNOWN", Error: "Internal error logging in"})
 		}


### PR DESCRIPTION
A POC snippet
```go
package main

import (
	"encoding/json"
	"log"
	"net/http"

	"go.mau.fi/mautrix-meta/pkg/connector"
)

func jsonResponse(w http.ResponseWriter, status int, response any) {
	w.Header().Add("Content-Type", "application/json")
	w.WriteHeader(status)
	_ = json.NewEncoder(w).Encode(response)
}

func main() {
	err := connector.ErrLoginChallenge
	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		// Returns {"ErrCode": "...", "Err": "..."}
		jsonResponse(w, err.StatusCode, err)
		// Returns {"errcode": "...", "err": "..."}
		// err.Write(w)
	})

	log.Fatal(http.ListenAndServe(":8080", nil))
}
```

Seems `RespError` becomes `any` in `jsonResponse`, so `func (e *RespError) MarshalJSON() ([]byte, error)` is not used.