### PR TITLE
Check for nil client/syncmanager before requesting history

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -126,6 +126,9 @@ func (m *MetaClient) handleUpdateExistingMessageRange(tk handlerParams, rng *tab
 }
 
 func (m *MetaClient) requestMoreHistory(ctx context.Context, threadID, minTimestampMS int64, minMessageID string) bool {
+	if m.Client == nil || m.Client.SyncManager == nil {
+		return false
+	}
 	resp, err := m.Client.ExecuteTasks(&socket.FetchMessagesTask{
 		ThreadKey:            threadID,
 		Direction:            0,


### PR DESCRIPTION
Needed here because this method gets fired off in background goroutines meaning they might be nil-ed by the time it executes.