### PR TITLE
Retry loading messages page

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -122,6 +122,8 @@ func (m *MetaClient) getProxy(reason string) (string, error) {
 	return respData.ProxyURL, nil
 }
 
+var ConnectRetries = 3
+
 func (m *MetaClient) Connect(ctx context.Context) {
 	if !m.connectLock.TryLock() {
 		zerolog.Ctx(ctx).Error().Msg("Connect called multiple times in parallel")
@@ -166,7 +168,7 @@ func (m *MetaClient) connectWithRetry(ctx context.Context, attempts int) {
 			return
 		}
 	}
-	currentUser, initialTable, err := m.Client.LoadMessagesPage()
+	currentUser, initialTable, err := m.Client.LoadMessagesPageWithRetries(ConnectRetries)
 	if err != nil {
 		zerolog.Ctx(ctx).Err(err).Msg("Failed to load messages page")
 		if stopPeriodicReconnect := m.stopPeriodicReconnect.Swap(nil); stopPeriodicReconnect != nil {

--- a/pkg/messagix/client.go
+++ b/pkg/messagix/client.go
@@ -125,6 +125,18 @@ func NewClient(cookies *cookies.Cookies, logger zerolog.Logger) *Client {
 	return cli
 }
 
+func (c *Client) LoadMessagesPageWithRetries(retries int) (info types.UserInfo, table *table.LSTable, err error) {
+	for i := range retries {
+		info, table, err = c.LoadMessagesPage()
+		if err == nil {
+			return
+		}
+		c.Logger.Warn().Err(err).Msgf("Failed to load messages page, retrying in %ds", retries)
+		time.Sleep(time.Second * time.Duration(i))
+	}
+	return
+}
+
 func (c *Client) LoadMessagesPage() (types.UserInfo, *table.LSTable, error) {
 	if c == nil {
 		return nil, nil, ErrClientIsNil


### PR DESCRIPTION
Seems sometimes we get errors parsing the output that a simple retry fixes.