### PR TITLE
Added temporary support for Dendrite instances

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 if [[ -z "$LIBRARY_PATH" && -d /opt/homebrew ]]; then
 	echo "Using /opt/homebrew for LIBRARY_PATH and CPATH"
 	export LIBRARY_PATH=/opt/homebrew/lib

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [[ -z "$GID" ]]; then
 	GID="$UID"
@@ -33,4 +33,4 @@ fi
 
 cd /data
 fixperms
-exec su-exec $UID:$GID /usr/bin/mautrix-meta
+exec su-exec $UID:$GID /usr/bin/mautrix-meta $@


### PR DESCRIPTION
I added a simple way to add extra command to ignore unsupported server so it can be compatible with [Dendrite instances](https://github.com/element-hq/dendrite). Also changed bash to sh for ease of compiling on multiple distros.

The bellow example worked for me:

```
image: ...
command: /docker-run.sh --ignore-unsupported-server
volumes: ...
```
