### PR TITLE
msgconv/from-whatsapp: Bridge replies to Facebook stories

### DIFF
--- a/pkg/msgconv/from-whatsapp.go
+++ b/pkg/msgconv/from-whatsapp.go
@@ -489,13 +489,13 @@ func (mc *MessageConverter) waExtendedContentMessageToMatrix(ctx context.Context
 			part.Content.EnsureHasHTML()
 			if nativeURL != "" {
 				part.Content.FormattedBody = fmt.Sprintf(
-					`<blockquote>Reply to <a href="%s">your Facebook story</a>:</blockquote><p>%s</p>`,
+					`<blockquote>Reply to <a href="%s">Facebook story</a>:</blockquote><p>%s</p>`,
 					nativeURL,
 					part.Content.FormattedBody,
 				)
 			} else {
 				part.Content.FormattedBody = fmt.Sprintf(
-					`<blockquote>Reply to your Facebook story:</blockquote><p>%s</p>`,
+					`<blockquote>Reply to Facebook story:</blockquote><p>%s</p>`,
 					part.Content.FormattedBody,
 				)
 			}


### PR DESCRIPTION
BRI-32931

The previous behavior was that when a user replied to your Facebook story, the bridge would only display the URL of the story that was replied to, and would discard the actual reply message contents. With this change, the reply is shown instead of the URL, using a blockquote to provide context that this is a reply to a story. In the case that other types of messages can be submitted as replies to Facebook stories (e.g. images), it's unclear to me what would happen, but I think there's a chance things would just work.

The Messenger interface displays the message as an actual reply, but it's not a reply to a Messenger message, so this is not straightforward to replicate in the current data model.

### Facebook Messenger web interface

<img width="1082" height="666" alt="image" src="https://github.com/user-attachments/assets/f66b0446-1846-4931-b4cf-7495403fdf8d" />

### Beeper desktop interface

<img width="1094" height="314" alt="image" src="https://github.com/user-attachments/assets/a33dbdf8-1304-4f9c-9d77-30703bd5a371" />

### Bonus

I noticed that there are protobufs for responses to Instagram stories, too. Do we need to support those? I checked to see what happens, and no, those are already handled by the bridge as is:

<img width="1016" height="952" alt="image" src="https://github.com/user-attachments/assets/3f4ba27f-1509-4fe3-be93-bfa64ab392ad" />
