### PR TITLE
msgconv: Fix multi-image direct media

### DIFF
--- a/pkg/metaid/mediaid.go
+++ b/pkg/metaid/mediaid.go
@@ -10,43 +10,116 @@ import (
 type DirectMediaType byte
 
 const (
-	DirectMediaTypeMeta     DirectMediaType = 2
-	DirectMediaTypeWhatsApp DirectMediaType = 3
+	// deprecated due to bug around handling multiple media
+	// attachments in a single message
+	DirectMediaTypeMetaV1     DirectMediaType = 2
+	DirectMediaTypeWhatsAppV1 DirectMediaType = 3
+
+	// recommended for current use
+	DirectMediaTypeMetaV2     DirectMediaType = 4
+	DirectMediaTypeWhatsAppV2 DirectMediaType = 5
 )
+
+func (t DirectMediaType) isSupported() bool {
+	switch t {
+	case
+		DirectMediaTypeMetaV1, DirectMediaTypeWhatsAppV1,
+		DirectMediaTypeMetaV2, DirectMediaTypeWhatsAppV2:
+		return true
+	}
+	return false
+}
+
+func (t DirectMediaType) includesPartID() bool {
+	switch t {
+	case DirectMediaTypeMetaV1, DirectMediaTypeWhatsAppV1:
+		return false
+	}
+	return true
+}
 
 type MediaInfo struct {
 	Type      DirectMediaType
 	UserID    networkid.UserLoginID
 	MessageID networkid.MessageID
+	PartID    networkid.PartID
 }
 
-func MakeMediaID(mediaType DirectMediaType, userID networkid.UserLoginID, messageID networkid.MessageID) networkid.MediaID {
-	mediaID := make([]byte, 1, 10+len(messageID))
+func MakeMediaID(mediaType DirectMediaType, userID networkid.UserLoginID, messageID networkid.MessageID, partID networkid.PartID) networkid.MediaID {
+	mediaID := make([]byte, 1, 11+len(messageID)+len(partID))
 	mediaID[0] = byte(mediaType)
 	mediaID = binary.BigEndian.AppendUint64(mediaID, uint64(ParseUserLoginID(userID)))
 	mediaID = append(mediaID, byte(len(messageID)))
 	mediaID = append(mediaID, messageID...)
+	if mediaType.includesPartID() {
+		mediaID = append(mediaID, byte(len(partID)))
+		mediaID = append(mediaID, partID...)
+	}
 	return mediaID
 }
 
 func ParseMediaID(mediaID networkid.MediaID) (*MediaInfo, error) {
-	if len(mediaID) < 10 {
-		return nil, fmt.Errorf("media ID too short: %d bytes", len(mediaID))
+	var info MediaInfo
+
+	ptr := 0
+	read := func(size int, what string) ([]byte, error) {
+		if len(mediaID) < ptr+size {
+			return nil, fmt.Errorf("media ID too short (%d bytes) to read %d byte %s starting at byte %d", len(mediaID), size, what, ptr)
+		}
+		b := mediaID[ptr : ptr+size]
+		ptr += size
+		return b, nil
 	}
-	mediaType := DirectMediaType(mediaID[0])
-	switch mediaType {
-	case DirectMediaTypeMeta, DirectMediaTypeWhatsApp:
-	default:
-		return nil, fmt.Errorf("unrecognized media type %d", mediaType)
-	}
-	messageIDLength := int(mediaID[9])
-	if len(mediaID) != 10+messageIDLength {
-		return nil, fmt.Errorf("unexpected media ID length, message ID byte says 10+%d, actual is %d", messageIDLength, len(mediaID))
+	readOne := func(what string) (byte, error) {
+		b, err := read(1, what)
+		if err != nil {
+			return 0, err
+		}
+		return b[0], nil
 	}
 
-	return &MediaInfo{
-		Type:      mediaType,
-		UserID:    MakeUserLoginID(int64(binary.BigEndian.Uint64(mediaID[1:9]))),
-		MessageID: networkid.MessageID(mediaID[10 : 10+messageIDLength]),
-	}, nil
+	c, err := readOne("media type")
+	if err != nil {
+		return nil, err
+	}
+	info.Type = DirectMediaType(c)
+
+	if !info.Type.isSupported() {
+		return nil, fmt.Errorf("unrecognized media type %d", info.Type)
+	}
+
+	b, err := read(8, "user id")
+	if err != nil {
+		return nil, err
+	}
+	info.UserID = MakeUserLoginID(int64(binary.BigEndian.Uint64(b)))
+
+	c, err = readOne("message id length")
+	if err != nil {
+		return nil, err
+	}
+	messageIDLength := int(c)
+
+	b, err = read(messageIDLength, "message id")
+	if err != nil {
+		return nil, err
+	}
+	info.MessageID = networkid.MessageID(b)
+
+	if info.Type.includesPartID() {
+		c, err = readOne("part id length")
+		if err != nil {
+			return nil, err
+		}
+		partIDLength := int(c)
+
+		b, err = read(partIDLength, "part id")
+		if err != nil {
+			return nil, err
+		}
+
+		info.PartID = networkid.PartID(b)
+	}
+
+	return &info, nil
 }

--- a/pkg/msgconv/from-whatsapp.go
+++ b/pkg/msgconv/from-whatsapp.go
@@ -159,7 +159,11 @@ func (mc *MessageConverter) reuploadWhatsAppAttachment(
 
 	if mc.DirectMedia {
 		msgID := ctx.Value(contextKeyMsgID).(networkid.MessageID)
-		mediaID := metaid.MakeMediaID(metaid.DirectMediaTypeWhatsApp, portal.Receiver, msgID)
+		var partID networkid.PartID
+		if ctx.Value(contextKeyPartID) != nil {
+			partID = ctx.Value(contextKeyPartID).(networkid.PartID)
+		}
+		mediaID := metaid.MakeMediaID(metaid.DirectMediaTypeWhatsAppV2, portal.Receiver, msgID, partID)
 		content := &event.MessageEventContent{
 			Info: &event.FileInfo{
 				MimeType: transport.GetAncillary().GetMimetype(),

--- a/pkg/msgconv/msgconv.go
+++ b/pkg/msgconv/msgconv.go
@@ -73,4 +73,5 @@ const (
 	contextKeyPortal
 	contextKeyFetchXMA
 	contextKeyMsgID
+	contextKeyPartID
 )


### PR DESCRIPTION
When using direct media mode (for Beeper, this means a local bridge as opposed to cloud or self-hosted), messages with N image attachments would instead render as N copies of the first image attachment, when received in a group chat (as opposed to a DM).

This is because the image attachments were transformed into direct media objects, which are given unique IDs that encode information used to look up metadata for them later. However, the unique ID was only based on the message ID, leading to all attachments from the same message being treated identically. In the code path where message IDs were decoded and actioned upon, there was a suspicious use of `GetFirstPartByID` rather than `GetPartByID`, which resulted in only the first attachment being used in each case.

New enum values for direct media types are introduced, which support encoding a part ID alongside the message ID, and the old ones are deprecated (but support is retained). The code for parsing media IDs was refactored to be easier to understand, due to the addition of more code paths. Finally, calling code was adjusted to attach appropriate unique values for message part IDs to the context, so that it can be used when constructing media IDs if present. This context augmentation only needs to happen in cases where there may be multiple media attachments in the same message. Since that does not appear to be possible in WhatsApp (multiple images can be sent at once, but are processed as separate messages), only the Meta code paths are modified.

This solves BRI-33018 and related tickets.
