### PR TITLE
messagix/dgw: simplify ack waiting and close handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/zyedidia/clipboard v1.0.4
 	go.mau.fi/libsignal v0.2.0
-	go.mau.fi/util v0.9.0
+	go.mau.fi/util v0.9.1-0.20250916094949-914cf963df1d
 	go.mau.fi/whatsmeow v0.0.0-20250826144440-85e30ecab38b
 	golang.org/x/crypto v0.41.0
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/zyedidia/clipboard v1.0.4 h1:r6GUQOyPtIaApRLeD56/U+2uJbXis6ANGbKWCljU
 github.com/zyedidia/clipboard v1.0.4/go.mod h1:zykFnZUXX0ErxqvYLUFEq7QDJKId8rmh2FgD0/Y8cjA=
 go.mau.fi/libsignal v0.2.0 h1:oRXj3OHhEJq51BFEM8/50UZblmWiTYH93hsNTPcbk90=
 go.mau.fi/libsignal v0.2.0/go.mod h1:tvjoDsMejgT38CXTXwqaYu8itBiY8O2Mb6biWvZBb9k=
-go.mau.fi/util v0.9.0 h1:ya3s3pX+Y8R2fgp0DbE7a0o3FwncoelDX5iyaeVE8ls=
-go.mau.fi/util v0.9.0/go.mod h1:pdL3lg2aaeeHIreGXNnPwhJPXkXdc3ZxsI6le8hOWEA=
+go.mau.fi/util v0.9.1-0.20250916094949-914cf963df1d h1:bXXmFKHQcBEc18/cIbXy3fmr70nW2J9fHVwBkdK3Ho4=
+go.mau.fi/util v0.9.1-0.20250916094949-914cf963df1d/go.mod h1:pdL3lg2aaeeHIreGXNnPwhJPXkXdc3ZxsI6le8hOWEA=
 go.mau.fi/whatsmeow v0.0.0-20250826144440-85e30ecab38b h1:E7KTA46O96g4PVMhVeJrkghA+6S/pFizo4xDMvv8PdQ=
 go.mau.fi/whatsmeow v0.0.0-20250826144440-85e30ecab38b/go.mod h1:xD0DR3s4T6PDd3BzgQG05AzLWxdKCmnvdCP3UuQvn9w=
 go.mau.fi/zeroconfig v0.2.0 h1:e/OGEERqVRRKlgaro7E6bh8xXiKFSXB3eNNIud7FUjU=

--- a/pkg/messagix/dgw/dgwsocket.go
+++ b/pkg/messagix/dgw/dgwsocket.go
@@ -354,6 +354,8 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 
 	wg.Wait()
 
+	s.client.GetLogger().Debug().Msg("DGW socket closed")
+
 	// Return the error, if any, saved from another goroutine.
 	return *s.err.Load()
 }

--- a/pkg/messagix/dgw/dgwsocket.go
+++ b/pkg/messagix/dgw/dgwsocket.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
+	"go.mau.fi/util/exsync"
 
 	"go.mau.fi/mautrix-meta/pkg/messagix/cookies"
 	"go.mau.fi/mautrix-meta/pkg/messagix/socket"
@@ -37,17 +38,11 @@ type Socket struct {
 	client MessagixClient
 	conn   *websocket.Conn
 	err    atomic.Pointer[error]
-
-	ackSubscription atomic.Bool
-	ackParameters   atomic.Bool
-
-	activity *sync.Cond
 }
 
 func NewSocketClient(c MessagixClient) *Socket {
 	return &Socket{
-		client:   c,
-		activity: &sync.Cond{L: &sync.Mutex{}},
+		client: c,
 	}
 }
 
@@ -122,25 +117,11 @@ type DGWTypingActivityIndicator struct {
 var activityIndicatorPathRegexp = regexp.MustCompile(`^/direct_v2/threads/([0-9]+)/activity_indicator_id/([0-9a-f-]+)$`)
 
 func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
-
-	done := atomic.Bool{}
-	markDone := func() {
-		done.Store(true)
-		s.activity.Broadcast()
-	}
-	waitDone := func() <-chan struct{} {
-		ch := make(chan struct{})
-		go func() {
-			s.activity.L.Lock()
-			for !done.Load() {
-				s.activity.Wait()
-			}
-			s.activity.L.Unlock()
-			ch <- struct{}{}
-			close(ch)
-		}()
-		return ch
-	}
+	done := make(chan struct{})
+	markDone := sync.OnceFunc(func() {
+		close(done)
+	})
+	var wg sync.WaitGroup
 
 	// Setup a function to call if we get a fatal error, that will
 	// close the connection and store the error so that it can be
@@ -163,7 +144,9 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 
 	// Copy inbound frames from the websocket to the channel.
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		defer close(incoming)
 		for {
 			msgtype, data, err := conn.ReadMessage()
@@ -190,11 +173,12 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 
 	// Copy outbound frames from the channel to the websocket.
 
+	wg.Add(1)
 	go func() {
-		waitDoneCh := waitDone()
+		defer wg.Done()
 		for {
 			select {
-			case <-waitDoneCh:
+			case <-done:
 				return
 			case frame := <-outgoing:
 				b, err := frame.Marshal()
@@ -217,16 +201,15 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 	pongTimeoutTimer := time.NewTimer(PongTimeout)
 	defer pongTimeoutTimer.Stop()
 
+	wg.Add(1)
 	go func() {
-		waitDoneCh := waitDone()
+		defer wg.Done()
 		for {
 			select {
 			case <-pongTimeoutTimer.C:
 				fatalError(fmt.Errorf("pong timeout"))
 				return
-			case <-waitDoneCh:
-				return
-			case <-ctx.Done():
+			case <-done:
 				return
 			}
 		}
@@ -235,7 +218,12 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 	// Process incoming frames from the channel and take any
 	// needed action based on their contents.
 
+	ackSubscription := exsync.NewEvent()
+	ackParameters := exsync.NewEvent()
+
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for frame := range incoming {
 			switch f := frame.(type) {
 			case *UnsupportedFrame:
@@ -257,8 +245,7 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 					fatalError(fmt.Errorf("error %d from EstabStream response", f.Parameters.StatusCode))
 					continue
 				}
-				s.ackSubscription.Store(true)
-				s.activity.Broadcast()
+				ackSubscription.Set()
 			case *DataFrame:
 				if f.RequiresAck {
 					outgoing <- &AckFrame{
@@ -307,48 +294,41 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 					s.client.GetLogger().Warn().Any("frame", f).Msg("Encountered ack with unknown ack id, dropping")
 					continue
 				}
-				s.ackParameters.Store(true)
-				s.activity.Broadcast()
+				ackParameters.Set()
 			}
 		}
 	}()
 
 	// Set up a ping timer.
 
-	pingTicker := time.NewTicker(PingInterval)
-	defer pingTicker.Stop()
+	wg.Add(1)
 	go func() {
-		for range pingTicker.C {
-			outgoing <- &PingFrame{}
+		pingTicker := time.NewTicker(PingInterval)
+		defer wg.Done()
+		defer pingTicker.Stop()
+		for {
+			select {
+			case <-pingTicker.C:
+				outgoing <- &PingFrame{}
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 
 	s.client.GetLogger().Debug().Msg("Initiating DGW socket handshake")
 
-	// Create a function to help with timing out waiting on ack
-	// frames if no response comes.
-
-	getAckTimeout := func() *atomic.Bool {
-		ackTimeout := atomic.Bool{}
-		time.AfterFunc(AckTimeout, func() {
-			ackTimeout.Store(true)
-			s.activity.Broadcast()
-		})
-		return &ackTimeout
-	}
-
 	// Send a frame to subscribe to typing indicators (1 of 2)
 
 	outgoing <- s.getTypingIndicatorSubscriptionFrame()
-
-	ackTimeout := getAckTimeout()
-	s.activity.L.Lock()
-	for !s.ackSubscription.Load() && !ackTimeout.Load() {
-		s.activity.Wait()
-	}
-	s.activity.L.Unlock()
-	if ackTimeout.Load() {
-		return fmt.Errorf("didn't get ack for first subscription frame")
+	err := ackSubscription.WaitTimeoutCtx(ctx, AckTimeout)
+	if err != nil {
+		err = fmt.Errorf("didn't get ack for first subscription frame: %w", err)
+		fatalError(err)
+		wg.Wait()
+		return err
 	}
 
 	// Send a frame to subscribe to typing indicators (2 of 2)
@@ -358,21 +338,23 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 		return err
 	}
 	outgoing <- frame
-
-	ackTimeout = getAckTimeout()
-	s.activity.L.Lock()
-	for !s.ackParameters.Load() && !ackTimeout.Load() {
-		s.activity.Wait()
-	}
-	s.activity.L.Unlock()
-	if ackTimeout.Load() {
-		return fmt.Errorf("didn't get ack for second subscription frame")
+	err = ackParameters.WaitTimeoutCtx(ctx, AckTimeout)
+	if err != nil {
+		err = fmt.Errorf("didn't get ack for second subscription frame: %w", err)
+		fatalError(err)
+		wg.Wait()
+		return err
 	}
 
 	s.client.GetLogger().Debug().Msg("DGW socket handshake is completed")
 
-	// Wait until done.
-	<-waitDone()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		fatalError(ctx.Err())
+	}
+
+	wg.Wait()
 
 	// Return the error, if any, saved from another goroutine.
 	return *s.err.Load()

--- a/pkg/messagix/dgw/dgwsocket.go
+++ b/pkg/messagix/dgw/dgwsocket.go
@@ -312,8 +312,6 @@ func (s *Socket) readLoop(ctx context.Context, conn *websocket.Conn) error {
 				outgoing <- &PingFrame{}
 			case <-done:
 				return
-			case <-ctx.Done():
-				return
 			}
 		}
 	}()


### PR DESCRIPTION
`sync.Cond`s are annoyingly complicated, in most cases the value they check is never actually cleared anyway. This replaces the close waiter with a simple channel and the acks with an `exsync.Event` (although maybe those should be closable channels too 🤔)

Also
* wait for all goroutines to exit before returning to make sure none of them are left behind
* make sure fatalError is called in all error cases
* actually stop the ping ticker loop (stopping a timer doesn't close the channel)
