### PR TITLE
connector: Instagram typing activity config

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -65,12 +65,18 @@ type MetaClient struct {
 	igUserIDsReverse map[int64]string
 }
 
+func (m *MetaConnector) getMessagixConfig() *messagix.Config {
+	return &messagix.Config{
+		MayConnectToDGW: m.Config.ReceiveInstagramTypingIndicators,
+	}
+}
+
 func (m *MetaConnector) LoadUserLogin(ctx context.Context, login *bridgev2.UserLogin) error {
 	loginMetadata := login.Metadata.(*metaid.UserLoginMetadata)
 	var messagixClient *messagix.Client
 	if loginMetadata.Cookies != nil {
 		loginMetadata.Cookies.Platform = loginMetadata.Platform
-		messagixClient = messagix.NewClient(loginMetadata.Cookies, login.Log.With().Str("component", "messagix").Logger())
+		messagixClient = messagix.NewClient(loginMetadata.Cookies, login.Log.With().Str("component", "messagix").Logger(), m.getMessagixConfig())
 	}
 	c := &MetaClient{
 		Main:      m,
@@ -533,7 +539,7 @@ func (m *MetaClient) FullReconnect() {
 	m.connectWaiter.Clear()
 	m.e2eeConnectWaiter.Clear()
 	m.disconnect(false)
-	m.Client = messagix.NewClient(m.LoginMeta.Cookies, m.UserLogin.Log.With().Str("component", "messagix").Logger())
+	m.Client = messagix.NewClient(m.LoginMeta.Cookies, m.UserLogin.Log.With().Str("component", "messagix").Logger(), m.Main.getMessagixConfig())
 	m.Client.SetEventHandler(m.handleMetaEvent)
 	m.Connect(ctx)
 	m.lastFullReconnect = time.Now()

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -38,6 +38,8 @@ type Config struct {
 
 	// Only affects E2EE chats right now.
 	SendPresenceOnTyping bool `yaml:"send_presence_on_typing"`
+
+	ReceiveInstagramTypingIndicators bool `yaml:"receive_instagram_typing_indicators"`
 }
 
 type umConfig Config
@@ -70,6 +72,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "disable_xma_backfill")
 	helper.Copy(up.Bool, "disable_xma_always")
 	helper.Copy(up.Bool, "send_presence_on_typing")
+	helper.Copy(up.Bool, "receive_instagram_typing_indicators")
 }
 
 func (m *MetaConnector) GetConfig() (string, any, up.Upgrader) {

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -41,3 +41,9 @@ disable_xma_always: false
 # notifications? Currently, this only has an effect for E2EE chats on
 # Facebook/Messenger. Full presence bridging is not supported.
 send_presence_on_typing: false
+# Should the bridge, when operating in Instagram mode, subscribe to an
+# additional websocket to receive typing indicators from other users?
+# An additional connection is only needed for receiving Instagram
+# typing indicators; the existing connection(s) are sufficient to send
+# and receive typing indicators in all other cases.
+receive_instagram_typing_indicators: true

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -192,7 +192,7 @@ func (m *MetaCookieLogin) SubmitCookies(ctx context.Context, strCookies map[stri
 	}
 
 	log := m.User.Log.With().Str("component", "messagix").Logger()
-	client := messagix.NewClient(c, log)
+	client := messagix.NewClient(c, log, m.Main.getMessagixConfig())
 	if m.Main.Config.GetProxyFrom != "" || m.Main.Config.Proxy != "" {
 		client.GetNewProxy = m.Main.getProxy
 		if !client.UpdateProxy("login") {


### PR DESCRIPTION
New config option `receive_instagram_typing_indicators`, default true, to control whether the bridge will subscribe to Instagram typing activity indicators (only has an effect when bridge is running in Instagram mode). Previously the new feature was enabled unconditionally, but it may be undesired in some cases since it requires making an additional network connection.

Tested with option enabled and disabled in self-hosted bridge config and it seems to have the expected behavior in both cases.