### PR TITLE
client: default both wa + meta state to CONNECTING at start

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -161,6 +161,9 @@ func (m *MetaClient) Connect(ctx context.Context) {
 	}
 	defer m.connectLock.Unlock()
 	if m.metaState.StateEvent == "" && m.waState.StateEvent == "" {
+		// Ensure both states start at CONNECTING now
+		m.metaState.StateEvent = status.StateConnecting
+		m.waState.StateEvent = status.StateConnecting
 		m.UserLogin.BridgeState.Send(status.BridgeState{StateEvent: status.StateConnecting})
 	}
 	retryCtx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
Otherwise we might mask stuck `CONNECTING` states.
