### PR TITLE
msgconv: Fix sticker sizes and thumbs-up rendering

### DIFF
--- a/pkg/msgconv/from-meta.go
+++ b/pkg/msgconv/from-meta.go
@@ -324,12 +324,14 @@ func (mc *MessageConverter) legacyAttachmentToMatrix(ctx context.Context, att *t
 		mime = att.AttachmentMimeType
 	}
 	duration := att.PlayableDurationMs
+	var width, height int64
 	if url == "" {
 		url = att.PreviewUrl
 		mime = att.PreviewUrlMimeType
+		width, height = att.PreviewWidth, att.PreviewHeight
 	}
 	converted, err := mc.reuploadAttachment(
-		ctx, att.AttachmentType, url, att.Filename, mime, int(att.Filesize), int(att.PreviewWidth), int(att.PreviewHeight), int(duration),
+		ctx, att.AttachmentType, url, att.Filename, mime, int(att.Filesize), int(width), int(height), int(duration),
 	)
 	if err != nil {
 		zerolog.Ctx(ctx).Err(err).Msg("Failed to transfer media")


### PR DESCRIPTION
PLAT-31683, three issues here:
1. ~For some reason we were ignoring `PreviewWidth` and `PreviewHeight` for animated media. We weren't using different attributes for those media, we were just setting the width and height to zero. I don't understand why the original code was written the way it was, any context appreciated. I've updated it to use these attributes when available.~
2. It appears that Facebook actually renders all stickers at 96x96 pixels even though this doesn't match any of the width or height attributes associated with the data that comes in from the server. I figure we should just hardcode to match. I've added a code comment with more details. I wonder if this would have any adverse effects (e.g. maybe the logic is actually more complicated), feedback on suggested testing appreciated.
3. We were bridging the thumbs-up button as an emoji in E2EE chats but a sticker in non-E2EE chats. I've changed it to an emoji for all chats as that's more similar to what Facebook does (they don't actually render a sticker, and it's rendered at a different size than a sticker too). This change I feel pretty good about, but let me know if the implementation is bad.

## Messenger web client:

<img width="824" height="762" alt="image" src="https://github.com/user-attachments/assets/aaea4cd3-7632-49a0-9358-59224bb28d0b" />

## Bridged - after this change:

<img width="556" height="544" alt="image" src="https://github.com/user-attachments/assets/e25978d6-d222-4819-b47f-e56ea8a358ec" />

## Bridged - before this change:

<img width="2338" height="1726" alt="image" src="https://github.com/user-attachments/assets/0af8f73a-ae86-4de9-a9c3-4729384b1699" />
