### PR TITLE
msgconv/from-meta: Always add XMA caption

### DIFF
--- a/pkg/msgconv/from-meta.go
+++ b/pkg/msgconv/from-meta.go
@@ -565,20 +565,22 @@ func (mc *MessageConverter) fetchFullXMA(ctx context.Context, att *table.Wrapped
 			externalURL = fmt.Sprintf("https://www.instagram.com/stories/%s/%s/", att.HeaderTitle, match[1])
 		}
 		minimalConverted.Extra["external_url"] = externalURL
-		addExternalURLCaption(minimalConverted.Content, externalURL)
 		if !mc.ShouldFetchXMA(ctx) {
 			log.Debug().Msg("Not fetching XMA media")
 			minimalConverted.Extra["fi.mau.meta.xma_fetch_status"] = "skip"
+			addExternalURLCaption(minimalConverted.Content, externalURL)
 			return minimalConverted
 		}
 
 		if len(match) != 3 {
 			log.Warn().Str("action_url", att.CTA.ActionUrl).Msg("Failed to parse story action URL")
 			minimalConverted.Extra["fi.mau.meta.xma_fetch_status"] = "parse fail"
+			addExternalURLCaption(minimalConverted.Content, externalURL)
 			return minimalConverted
 		} else if resp, err := ig.FetchReel(ctx, []string{match[2]}, match[1]); err != nil {
 			log.Err(err).Str("action_url", att.CTA.ActionUrl).Msg("Failed to fetch XMA story")
 			minimalConverted.Extra["fi.mau.meta.xma_fetch_status"] = "fetch fail"
+			addExternalURLCaption(minimalConverted.Content, externalURL)
 			return minimalConverted
 		} else if reel, ok := resp.Reels[match[2]]; !ok {
 			log.Trace().
@@ -592,6 +594,7 @@ func (mc *MessageConverter) fetchFullXMA(ctx context.Context, att *table.Wrapped
 				Str("response_status", resp.Status).
 				Msg("Got empty XMA story response")
 			minimalConverted.Extra["fi.mau.meta.xma_fetch_status"] = "empty response"
+			addExternalURLCaption(minimalConverted.Content, externalURL)
 			return minimalConverted
 		} else {
 			log.Trace().
@@ -604,6 +607,7 @@ func (mc *MessageConverter) fetchFullXMA(ctx context.Context, att *table.Wrapped
 			// Update external URL to use username so it works on mobile
 			externalURL = fmt.Sprintf("https://www.instagram.com/stories/%s/%s/", reel.User.Username, match[1])
 			minimalConverted.Extra["external_url"] = externalURL
+			addExternalURLCaption(minimalConverted.Content, externalURL)
 			var relevantItem *responses.Items
 			foundIDs := make([]string, len(reel.Items))
 			for i, item := range reel.Items {
@@ -637,6 +641,7 @@ func (mc *MessageConverter) fetchFullXMA(ctx context.Context, att *table.Wrapped
 			secondConverted.Extra["com.beeper.instagram_item_username"] = reel.User.Username
 			if externalURL != "" {
 				secondConverted.Extra["external_url"] = externalURL
+				addExternalURLCaption(secondConverted.Content, externalURL)
 			}
 			secondConverted.Extra["fi.mau.meta.xma_fetch_status"] = "success"
 			return secondConverted
@@ -699,6 +704,7 @@ func (mc *MessageConverter) fetchFullXMA(ctx context.Context, att *table.Wrapped
 			secondConverted.Extra["com.beeper.instagram_item_username"] = relevantItem.User.Username
 			if externalURL != "" {
 				secondConverted.Extra["external_url"] = externalURL
+				addExternalURLCaption(secondConverted.Content, externalURL)
 			}
 			secondConverted.Extra["fi.mau.meta.xma_fetch_status"] = "success"
 			return secondConverted


### PR DESCRIPTION
PLAT-34930: We were adding a caption linking back to the original XMA post in this case:

https://github.com/mautrix/meta/blob/e5922038b162bf03a4910a3887cf2dd78c33847c/pkg/msgconv/from-meta.go#L509-L510

But not the other case. I added it there, since otherwise no information is shown to the user linking back or even indicating that it is a shared post.

Note that we have to repeat the caption generation because we throw away the original converted message while redownloading as XMA.