### PR TITLE
connector: re-request history backfill before timeout

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -243,7 +243,6 @@ func (m *MetaClient) FetchMessages(ctx context.Context, params bridgev2.FetchMes
 			return nil, fmt.Errorf("backfill collector already exists for thread %d", threadID)
 		}
 		defer m.removeBackfillCollector(threadID, collector)
-		// Figure out timeout, ticker 1/10th of that
 		start := time.Now()
 		timeout := BackfillTimeout
 		if params.Forward && bridgev2.PortalEventBuffer == 0 {


### PR DESCRIPTION
This seems to be a bug in the implementation where sync on reconnect indicates more messages are available on the server between the most recent we have and the insertion batch, we need to fetch those to fill the gap. Based on the logs it looks like for some threads we get 10 max messages and others 20.
