### PR TITLE
client: allow reconnecting after a Disconnect call

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -141,7 +141,7 @@ func (m *MetaConnector) getProxy(reason string) (string, error) {
 }
 
 func (m *MetaClient) ensureMessagixClient() {
-	if m.LoginMeta.Cookies != nil {
+	if m.LoginMeta.Cookies != nil && m.Client == nil {
 		m.LoginMeta.Cookies.Platform = m.LoginMeta.Platform
 		m.Client = messagix.NewClient(
 			m.LoginMeta.Cookies,


### PR DESCRIPTION
Because the client is only recreated during a full reconnect, currently if you connect -> disconnect -> connect the second connect will immediately fail and set the bridge state to bad credentials.
