### PR TITLE
messagix/instagram: treat missing Instagram thread as already deleted

### DIFF
--- a/pkg/messagix/instagram.go
+++ b/pkg/messagix/instagram.go
@@ -25,6 +25,10 @@ import (
 	"go.mau.fi/mautrix-meta/pkg/messagix/useragent"
 )
 
+// ErrIGThreadNotFound is returned when a route definition request succeeds
+// but the thread_fbid is missing, indicating the thread no longer exists on Instagram.
+var ErrIGThreadNotFound = errors.New("instagram thread not found")
+
 // specific methods for insta api, not socket related
 type InstagramMethods struct {
 	client *Client
@@ -255,7 +259,7 @@ func (ig *InstagramMethods) fetchRouteDefinition(ctx context.Context, threadID s
 	}
 	threadFBID := routeDefResp.Payload.Result.Exports.RootView.Props.ThreadFBID
 	if threadFBID == "" {
-		return "", fmt.Errorf("thread_fbid not found in route definition response for thread %s", threadID)
+		return "", fmt.Errorf("%w in route definition response for thread %s", ErrIGThreadNotFound, threadID)
 	}
 
 	zerolog.Ctx(ctx).Info().
@@ -269,6 +273,11 @@ func (ig *InstagramMethods) fetchRouteDefinition(ctx context.Context, threadID s
 func (ig *InstagramMethods) DeleteThread(ctx context.Context, threadID string) error {
 	id, err := ig.fetchRouteDefinition(ctx, threadID)
 	if err != nil {
+		if errors.Is(err, ErrIGThreadNotFound) {
+			zerolog.Ctx(ctx).Warn().Err(err).Str("thread_id", threadID).
+				Msg("Thread not found on Instagram, assuming already deleted")
+			return nil
+		}
 		return fmt.Errorf("failed to fetch route definition for thread %s: %w", threadID, err)
 	}
 	igVariables := &graphql.IGDeleteThreadGraphQLRequestPayload{


### PR DESCRIPTION
## Problem

When deleting an Instagram chat from Beeper that was already removed on the native Instagram app, the bridge enters an infinite retry loop.

The `DeleteThread` flow calls `fetchRouteDefinition` → `POST /ajax/route-definition/` to resolve the `thread_fbid`. When the thread no longer exists on Instagram, the endpoint returns 200 OK but with an empty `thread_fbid`, causing:

```
error="failed to fetch route definition for thread 116456373082512: thread_fbid not found in route definition response for thread 116456373082512"
status=FAIL_RETRIABLE
```

The `FAIL_RETRIABLE` status causes the client to retry indefinitely — a deletion that can never succeed.

## Fix

- Add `ErrIGThreadNotFound` sentinel error variable to `fetchRouteDefinition` (using `%w` wrapping)
- In `DeleteThread`, check for this error with `errors.Is` and return `nil` — the chat is already gone, so the deletion intent is fulfilled
- Log a warning for observability

Per Tulir's guidance in the ticket comments.

## Impact

- One file changed, 10 insertions, 1 deletion
- No new dependencies
- Only affects the Instagram `DeleteThread` path — all other callers of `fetchRouteDefinition` are unaffected

Fixes https://linear.app/beeper/issue/PLAT-36131