### PR TITLE
messagix/bloks: support bk.action.core.Let

### DIFF
--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -368,6 +368,23 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 			return first, nil
 		}
 		return i.Evaluate(ctx, &call.Args[1])
+	case "bk.action.core.Let":
+		// Lazy-init: return arg0 if non-null, else apply the FuncConst in arg1.
+		current, err := i.Evaluate(ctx, &call.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		if current.IsTruthy() {
+			return current, nil
+		}
+		init, err := evalAs[*BloksLambda](ctx, i, &call.Args[1], "let.init")
+		if err != nil {
+			return nil, err
+		}
+		newArgs := make([]*BloksScriptLiteral, maxInterpArgs)
+		copy(newArgs, init.BoundArgs)
+		ctx = context.WithValue(ctx, interpCtxArgs, newArgs)
+		return i.Evaluate(ctx, init.Body)
 	case "bk.action.bloks.GetVariable2", "bk.action.bloks.GetVariableWithScope":
 		// The second argument to the WithScope variant is an integer that may specify
 		// whether to get a local or global variable. For now, ignore.


### PR DESCRIPTION
Adds the missing `bk.action.core.Let` opcode. Without it, the Messenger Lite login flow fails on the email/password screen with `tapping login button: on_touch_down: unimplemented function bk.action.core.Let (2 args)` — Facebook's login script started using `Let` to lazy-init per-screen animation state.

`Let(currentOrNull, FuncConst(initializer))`: if `currentOrNull` evaluates to a non-null value (a previously cached value), return it; otherwise apply the FuncConst lambda in arg 1 and return its result. Implementation matches the existing `Coalesce` pattern plus the `Apply` lambda invocation.

Reproduced and verified against a real captured bundle: the on_touch_down handler now executes through to `com.bloks.www.bloks.caa.login.async.send_login_request` cleanly via `pkg/messagix/bloks/cmd -file <bundle> -action -login`.

Closes [PLAT-36280](https://linear.app/beeper/issue/PLAT-36280).