### PR TITLE
messagix/bloks: Allow logging redacted Bloks payloads

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -75,8 +75,9 @@ type MetaClient struct {
 
 func (m *MetaConnector) getMessagixConfig() *messagix.Config {
 	return &messagix.Config{
-		MayConnectToDGW: m.Config.ReceiveInstagramTypingIndicators,
-		ClientSettings:  m.Bridge.GetHTTPClientSettings(),
+		MayConnectToDGW:          m.Config.ReceiveInstagramTypingIndicators,
+		ClientSettings:           m.Bridge.GetHTTPClientSettings(),
+		LogRedactedBloksPayloads: m.Config.LogRedactedBloksPayloads,
 	}
 }
 

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	ReceiveInstagramTypingIndicators bool `yaml:"receive_instagram_typing_indicators"`
 	DisableViewOnce                  bool `yaml:"disable_view_once"`
 	MarketplaceSpace                 bool `yaml:"marketplace_space"`
+	LogRedactedBloksPayloads         bool `yaml:"log_redacted_bloks_payloads"`
 
 	ThreadBackfill ThreadBackfillConfig `yaml:"thread_backfill"`
 }
@@ -99,6 +100,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "receive_instagram_typing_indicators")
 	helper.Copy(up.Bool, "disable_view_once")
 	helper.Copy(up.Bool, "marketplace_space")
+	helper.Copy(up.Bool, "log_redacted_bloks_payloads")
 	helper.Copy(up.Int, "thread_backfill", "batch_count")
 	helper.Copy(up.Str|up.Int, "thread_backfill", "batch_delay")
 }

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -52,6 +52,8 @@ receive_instagram_typing_indicators: true
 disable_view_once: false
 # Should FB marketplace chats have a separate space inside the main Facebook space?
 marketplace_space: true
+# Log raw Bloks payloads even at debug level, with any user identifiers or credentials redacted.
+log_redacted_bloks_payloads: false
 
 # Thread backfill settings for syncing older conversations
 thread_backfill:

--- a/pkg/messagix/bloks/cmd/main.go
+++ b/pkg/messagix/bloks/cmd/main.go
@@ -53,6 +53,9 @@ func main() {
 }
 
 func readAndParse[T any](filename string) (*T, error) {
+	if filename == "-" {
+		filename = "/dev/stdin"
+	}
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err

--- a/pkg/messagix/bloks/cmd/main.go
+++ b/pkg/messagix/bloks/cmd/main.go
@@ -24,6 +24,7 @@ import (
 
 var filename = flag.String("file", "", "Bloks response to parse")
 var doPrint = flag.Bool("print", false, "Pretty-print the bundle")
+var doRedact = flag.Bool("redact", false, "Pretty-print the bundle but in redacted form")
 var doHTML = flag.Bool("html", false, "Print as HTML")
 var doLogin = flag.Bool("login", false, "Click the login button")
 var do2FA = flag.String("2fa", "", "Submit a two-factor code")
@@ -141,10 +142,14 @@ func mainE() error {
 		return err
 	}
 	if *doPrint {
-		return bundle.Print("")
+		return bundle.Print(os.Stdout, "")
+	}
+	if *doRedact {
+		bundle.Redact()
+		return bundle.Print(os.Stdout, "")
 	}
 	if *doHTML {
-		return bundle.PrintHTML("")
+		return bundle.PrintHTML(os.Stdout, "")
 	}
 	lastURL := ""
 	bridge := bloks.InterpBridge{
@@ -248,7 +253,7 @@ func mainE() error {
 			if !ok {
 				return false
 			}
-			str, ok := name.BloksJavascriptValue.(string)
+			str, ok := name.BloksJavaScriptValue.(string)
 			if !ok {
 				return false
 			}
@@ -283,7 +288,7 @@ func mainE() error {
 			if !ok {
 				return false
 			}
-			str, ok := text.BloksJavascriptValue.(string)
+			str, ok := text.BloksJavaScriptValue.(string)
 			if !ok {
 				return false
 			}
@@ -346,7 +351,7 @@ func mainE() error {
 				if !ok {
 					return false
 				}
-				str, ok := label.BloksJavascriptValue.(string)
+				str, ok := label.BloksJavaScriptValue.(string)
 				if !ok {
 					return false
 				}

--- a/pkg/messagix/bloks/script.go
+++ b/pkg/messagix/bloks/script.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 )
 
@@ -36,7 +37,8 @@ func (node *BloksScriptNode) ParseAny(code string, start int) (int, error) {
 type BloksScriptNodeContent interface {
 	Parse(code string, start int) (int, error)
 	Unminify(m *Unminifier)
-	Print(indent string) error
+	Print(w io.Writer, indent string) error
+	Redact()
 }
 
 type BloksScriptFuncall struct {
@@ -115,26 +117,47 @@ func (call *BloksScriptFuncall) Unminify(m *Unminifier) {
 	}
 }
 
-func (call *BloksScriptFuncall) Print(indent string) error {
-	fmt.Printf("%s(%s", indent, call.Function)
+func (call *BloksScriptFuncall) Print(w io.Writer, indent string) error {
+	fmt.Fprintf(w, "%s(%s", indent, call.Function)
 	if len(call.Args) >= 1 {
-		fmt.Printf("\n")
+		fmt.Fprintf(w, "\n")
 	}
 	for idx, arg := range call.Args {
 		if idx > 0 {
-			fmt.Printf("\n")
+			fmt.Fprintf(w, "\n")
 		}
-		arg.Print(indent + "  ")
+		arg.Print(w, indent+"  ")
 	}
-	fmt.Printf(")")
+	fmt.Fprintf(w, ")")
 	return nil
 }
 
-type BloksScriptLiteral struct {
-	BloksJavascriptValue
+func (call *BloksScriptFuncall) Redact() {
+	nonsensitive := map[int]bool{}
+	switch call.Function {
+	case "bk.action.qpl.MarkerPoint":
+		nonsensitive[2] = true
+	case "bk.action.LogFlytrapData":
+		nonsensitive[1] = true
+	}
+	for idx, arg := range call.Args {
+		if nonsensitive[idx] {
+			switch arg.BloksScriptNodeContent.(type) {
+			case *BloksScriptLiteral:
+				continue
+			}
+		}
+		arg.Redact()
+	}
 }
 
-func BloksLiteralFromJavaScript(j BloksJavascriptValue) *BloksScriptLiteral {
+type BloksScriptLiteralValue any
+
+type BloksScriptLiteral struct {
+	BloksScriptLiteralValue
+}
+
+func BloksLiteralFromJavaScript(j BloksJavaScriptValue) *BloksScriptLiteral {
 	switch j := j.(type) {
 	case []any:
 		arr := []*BloksScriptLiteral{}
@@ -186,13 +209,13 @@ func (lit *BloksScriptLiteral) Parse(code string, start int) (int, error) {
 				if err != nil {
 					return idx, err
 				}
-				lit.BloksJavascriptValue = val
+				lit.BloksScriptLiteralValue = val
 			} else {
 				val, err := strconv.ParseInt(code[start:idx], 10, 64)
 				if err != nil {
 					return idx, err
 				}
-				lit.BloksJavascriptValue = val
+				lit.BloksScriptLiteralValue = val
 			}
 			return idx, nil
 		}
@@ -227,7 +250,7 @@ func (lit *BloksScriptLiteral) Parse(code string, start int) (int, error) {
 				}
 				continue
 			case '"':
-				lit.BloksJavascriptValue = string(chars)
+				lit.BloksScriptLiteralValue = string(chars)
 				return idx + 1, nil
 			}
 			chars = append(chars, code[idx])
@@ -239,14 +262,13 @@ func (lit *BloksScriptLiteral) Parse(code string, start int) (int, error) {
 		return start + 4, nil
 	}
 	if start+4 < len(code) && code[start:start+4] == "true" {
-		lit.BloksJavascriptValue = true
+		lit.BloksScriptLiteralValue = true
 		return start + 4, nil
 	}
 	if start+5 < len(code) && code[start:start+5] == "false" {
-		lit.BloksJavascriptValue = false
+		lit.BloksScriptLiteralValue = false
 		return start + 5, nil
 	}
-	fmt.Printf("context: %s\n", code)
 	return start, fmt.Errorf("unknown char %q", code[start])
 }
 
@@ -256,21 +278,27 @@ func (lit *BloksScriptLiteral) Unminify(m *Unminifier) {
 		return
 	}
 	if real, ok := m.Variables[BloksVariableID(str)]; ok && len(real) > 0 {
-		lit.BloksJavascriptValue = string(real)
+		lit.BloksScriptLiteralValue = string(real)
 	}
 }
 
-func (lit *BloksScriptLiteral) Print(indent string) error {
-	str, err := json.Marshal(lit.BloksJavascriptValue)
+func (lit *BloksScriptLiteral) Print(w io.Writer, indent string) error {
+	str, err := json.Marshal(lit.Flatten(false))
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s%s", indent, str)
+	fmt.Fprintf(w, "%s%s", indent, str)
 	return nil
 }
 
 func (lit *BloksScriptLiteral) Value() any {
-	return lit.BloksJavascriptValue
+	return lit.BloksScriptLiteralValue
+}
+
+func (lit *BloksScriptLiteral) Redact() {
+	val := lit.Flatten(false)
+	redactJavaScriptValue(&val)
+	*lit = *BloksLiteralOf(val)
 }
 
 func BloksLiteralOf(val any) *BloksScriptLiteral {
@@ -278,7 +306,7 @@ func BloksLiteralOf(val any) *BloksScriptLiteral {
 		panic("logic error, constructing nested literal")
 	}
 	return &BloksScriptLiteral{
-		BloksJavascriptValue(val),
+		BloksJavaScriptValue(val),
 	}
 }
 
@@ -289,7 +317,7 @@ type BloksIllegalValue struct{}
 var BloksNothing = BloksLiteralOf(&BloksIllegalValue{})
 
 func (lit *BloksScriptLiteral) IsTruthy() bool {
-	switch val := lit.BloksJavascriptValue.(type) {
+	switch val := lit.BloksScriptLiteralValue.(type) {
 	case bool:
 		return val
 	case string:
@@ -313,7 +341,7 @@ func (lit *BloksScriptLiteral) Flatten(facebookify bool) any {
 	case []*BloksScriptLiteral:
 		res := []any{}
 		for _, val := range lit {
-			res = append(res, val)
+			res = append(res, val.Flatten(facebookify))
 		}
 		return res
 	case bool:

--- a/pkg/messagix/bloks/script.go
+++ b/pkg/messagix/bloks/script.go
@@ -135,10 +135,23 @@ func (call *BloksScriptFuncall) Print(w io.Writer, indent string) error {
 func (call *BloksScriptFuncall) Redact() {
 	nonsensitive := map[int]bool{}
 	switch call.Function {
+	case "bk.action.qpl.MarkerAnnotate", "bk.action.qpl.MarkerEndV2":
+		nonsensitive[0] = true
 	case "bk.action.qpl.MarkerPoint":
+		nonsensitive[0] = true
 		nonsensitive[2] = true
 	case "bk.action.LogFlytrapData":
 		nonsensitive[1] = true
+	case "bk.action.bloks.WriteGlobalConsistencyStore":
+		nonsensitive[0] = true
+	case "bk.action.bloks.GetVariable2":
+		nonsensitive[0] = true
+	case "bk.action.bloks.GetScript":
+		nonsensitive[0] = true
+	case "bk.action.bloks.GetPayload":
+		nonsensitive[0] = true
+	case "bk.action.template.Make":
+		nonsensitive[0] = true
 	}
 	for idx, arg := range call.Args {
 		if nonsensitive[idx] {

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -159,7 +159,7 @@ func (comp *BloksTreeComponent) GetAttribute(name BloksAttributeID) string {
 	if !ok {
 		return ""
 	}
-	str, ok := value.BloksJavascriptValue.(string)
+	str, ok := value.BloksJavaScriptValue.(string)
 	if !ok {
 		return ""
 	}

--- a/pkg/messagix/bloks/tree.go
+++ b/pkg/messagix/bloks/tree.go
@@ -2,8 +2,12 @@ package bloks
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -82,18 +86,18 @@ func (bb *BloksBundle) Unminify(m *Unminifier) {
 	}
 }
 
-func (bb *BloksBundle) Print(indent string) error {
+func (bb *BloksBundle) Print(w io.Writer, indent string) error {
 	p := &bb.Layout.Payload
-	fmt.Printf("%s<Bundle>\n", indent)
+	fmt.Fprintf(w, "%s<Bundle>\n", indent)
 	if p.VariablesOwner == p {
 		for _, datum := range p.Variables {
-			fmt.Printf("%s  <Datum id=%q>\n", indent, datum.ID)
+			fmt.Fprintf(w, "%s  <Datum id=%q>\n", indent, datum.ID)
 			if datum.Info.InitialScript != nil {
-				datum.Info.InitialScript.Print(indent + "    ")
+				datum.Info.InitialScript.Print(w, indent+"    ")
 			} else {
-				BloksLiteralFromJavaScript(datum.Info.Initial).Print(indent + "    ")
+				BloksLiteralFromJavaScript(datum.Info.Initial).Print(w, indent+"    ")
 			}
-			fmt.Printf("\n%s  </Datum id=%q>\n", indent, datum.ID)
+			fmt.Fprintf(w, "\n%s  </Datum id=%q>\n", indent, datum.ID)
 		}
 	}
 	scriptIDs := []BloksScriptID{}
@@ -103,14 +107,14 @@ func (bb *BloksBundle) Print(indent string) error {
 	slices.Sort(scriptIDs)
 	for _, id := range scriptIDs {
 		script := p.Scripts[id]
-		fmt.Printf("%s  <Script id=%q>\n", indent, id)
-		script.Print(indent + "    ")
-		fmt.Printf("\n%s  </Script id=%q>\n", indent, id)
+		fmt.Fprintf(w, "%s  <Script id=%q>\n", indent, id)
+		script.Print(w, indent+"    ")
+		fmt.Fprintf(w, "\n%s  </Script id=%q>\n", indent, id)
 	}
 	for _, emb := range p.Embedded {
-		fmt.Printf("%s  <EmbeddedPayload id=%q>\n", indent, emb.ID)
-		emb.Contents.Print(indent + "    ")
-		fmt.Printf("%s  </EmbeddedPayload id=%q>\n", indent, emb.ID)
+		fmt.Fprintf(w, "%s  <EmbeddedPayload id=%q>\n", indent, emb.ID)
+		emb.Contents.Print(w, indent+"    ")
+		fmt.Fprintf(w, "%s  </EmbeddedPayload id=%q>\n", indent, emb.ID)
 	}
 	templateIDs := []BloksTemplateID{}
 	for id := range p.Templates {
@@ -119,45 +123,66 @@ func (bb *BloksBundle) Print(indent string) error {
 	slices.Sort(templateIDs)
 	for _, id := range templateIDs {
 		template := p.Templates[id]
-		fmt.Printf("%s  <Template id=%q>\n", indent, id)
-		template.Print(indent + "    ")
-		fmt.Printf("%s  </Template id=%q>\n", indent, id)
+		fmt.Fprintf(w, "%s  <Template id=%q>\n", indent, id)
+		template.Print(w, indent+"    ")
+		fmt.Fprintf(w, "%s  </Template id=%q>\n", indent, id)
 	}
 	if p.Tree != nil {
-		fmt.Printf("%s  <Tree>\n", indent)
-		err := p.Tree.Print(indent + "    ")
+		fmt.Fprintf(w, "%s  <Tree>\n", indent)
+		err := p.Tree.Print(w, indent+"    ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s  </Tree>\n", indent)
+		fmt.Fprintf(w, "%s  </Tree>\n", indent)
 	}
 	if p.Action != nil {
-		fmt.Printf("%s  <Action>\n", indent)
-		err := p.Action.Print(indent + "    ")
+		fmt.Fprintf(w, "%s  <Action>\n", indent)
+		err := p.Action.Print(w, indent+"    ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("\n%s  </Action>\n", indent)
+		fmt.Fprintf(w, "\n%s  </Action>\n", indent)
 	}
-	fmt.Printf("%s</Bundle>\n", indent)
+	fmt.Fprintf(w, "%s</Bundle>\n", indent)
 	return nil
 }
 
-func (bb *BloksBundle) PrintHTML(indent string) error {
-	fmt.Printf("%s<!DOCTYPE html>\n", indent)
-	fmt.Printf("%s<html>\n", indent)
-	fmt.Printf("%s  <head>\n", indent)
-	fmt.Printf("%s    <meta charset=\"utf-8\">\n", indent)
-	fmt.Printf("%s    <title>Bloks Page</title>\n", indent)
-	fmt.Printf("%s  </head>\n", indent)
-	fmt.Printf("%s  <body>\n", indent)
-	err := bb.Layout.Payload.Tree.PrintHTML(indent + "    ")
+func (bb *BloksBundle) PrintHTML(w io.Writer, indent string) error {
+	fmt.Fprintf(w, "%s<!DOCTYPE html>\n", indent)
+	fmt.Fprintf(w, "%s<html>\n", indent)
+	fmt.Fprintf(w, "%s  <head>\n", indent)
+	fmt.Fprintf(w, "%s    <meta charset=\"utf-8\">\n", indent)
+	fmt.Fprintf(w, "%s    <title>Bloks Page</title>\n", indent)
+	fmt.Fprintf(w, "%s  </head>\n", indent)
+	fmt.Fprintf(w, "%s  <body>\n", indent)
+	err := bb.Layout.Payload.Tree.PrintHTML(w, indent+"    ")
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s  </body>\n", indent)
-	fmt.Printf("%s</html>\n", indent)
+	fmt.Fprintf(w, "%s  </body>\n", indent)
+	fmt.Fprintf(w, "%s</html>\n", indent)
 	return nil
+}
+
+func (bb *BloksBundle) Redact() {
+	p := &bb.Layout.Payload
+	if p.VariablesOwner == p {
+		for _, datum := range p.Variables {
+			redactJavaScriptValue((*any)(&datum.Info.Initial))
+			datum.Info.InitialScript.Redact()
+		}
+	}
+	for _, scr := range p.Scripts {
+		scr.Redact()
+	}
+	for _, emb := range p.Embedded {
+		emb.Contents.Redact()
+	}
+	for _, tmp := range p.Templates {
+		tmp.Redact()
+	}
+	p.Tree.Redact()
+	p.Action.Redact()
 }
 
 type BloksLayout struct {
@@ -188,11 +213,87 @@ type BloksVariable struct {
 type BloksDatumInfo struct {
 	Name          string               `json:"key"`
 	Mode          string               `json:"mode"`
-	Initial       BloksJavascriptValue `json:"initial"`
+	Initial       BloksJavaScriptValue `json:"initial"`
 	InitialScript *BloksTreeScript     `json:"initial_lispy"`
 }
 
-type BloksJavascriptValue any
+type BloksJavaScriptValue any
+
+var likelyNonSensitive = regexp.MustCompile(strings.Join([]string{
+	// attr name like "extra_client_data_bks_input" or "should_trigger_override_login_2fa_action"
+	`^[a-z2]{2,12}(_[a-z2]{2,12})+$`,
+	// english sentence or display name
+	`^[A-Za-z']{1,12}( [A-Za-z']{1,12}[.,]?)+ *$`,
+	// clearly internal identifiers
+	`^com.bloks.`,
+	`^(CAA|caa|INTERNAL)_`,
+	`^i:(caa|com\.bloks)\.`,
+	// cdn url, not user specific
+	`^rsrc.php/`,
+}, `|`))
+
+var stringTypes = map[string]*regexp.Regexp{
+	"uuid_lowercase": regexp.MustCompile(`^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}`),
+	"uuid_uppercase": regexp.MustCompile(`^[0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12}`),
+	"hex":            regexp.MustCompile(`^[0-9a-f]+$`),
+}
+
+var likelyURL = regexp.MustCompile(`^([a-z]{2,10}://[a-z0-9.-]+/)(.+)$`)
+
+func redactString(s string) string {
+	if strings.HasPrefix(s, "redacted_") {
+		return s
+	}
+	var obj any
+	err := json.Unmarshal([]byte(s), &obj)
+	if err == nil {
+		redactJavaScriptValue(&obj)
+		out, err := json.Marshal(obj)
+		if err == nil {
+			return string(out)
+		}
+	}
+	if len(s) < 20 {
+		return s
+	}
+	if likelyNonSensitive.MatchString(s) {
+		return s
+	}
+	prefix := ""
+	if match := likelyURL.FindStringSubmatch(s); match != nil {
+		prefix = match[1]
+		s = match[2]
+	}
+	if likelyNonSensitive.MatchString(s) {
+		return prefix + s
+	}
+	stringType := "str"
+	for guess, regex := range stringTypes {
+		if regex.MatchString(s) {
+			stringType = guess
+			break
+		}
+	}
+	digest := sha256.New().Sum([]byte(s))
+	return fmt.Sprintf("%sredacted_%dchar_%s_%s", prefix, len(s), stringType, hex.EncodeToString(digest[:4]))
+}
+
+func redactJavaScriptValue(ptr *any) {
+	switch val := (*ptr).(type) {
+	case string:
+		*ptr = redactString(val)
+	case []any:
+		for idx := range val {
+			redactJavaScriptValue(&val[idx])
+		}
+	case map[string]any:
+		for key := range val {
+			obj := val[key]
+			redactJavaScriptValue(&obj)
+			val[key] = obj
+		}
+	}
+}
 
 type BloksEmbeddedPayload struct {
 	ID       BloksPayloadID `json:"id"`
@@ -251,7 +352,7 @@ func (btn *BloksTreeNode) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	if str, ok := literal.BloksJavascriptValue.(string); ok && (strings.HasPrefix(str, "\t") || strings.HasPrefix(str, "(")) {
+	if str, ok := literal.BloksJavaScriptValue.(string); ok && (strings.HasPrefix(str, "\t") || strings.HasPrefix(str, "(")) {
 		script := BloksTreeScript{}
 		err := script.Parse(str)
 		if err != nil {
@@ -260,7 +361,7 @@ func (btn *BloksTreeNode) UnmarshalJSON(data []byte) error {
 		btn.BloksTreeNodeContent = &script
 		return nil
 	}
-	if arr, ok := literal.BloksJavascriptValue.([]any); ok {
+	if arr, ok := literal.BloksJavaScriptValue.([]any); ok {
 		set := BloksTreeScriptSet{
 			Scripts: map[BloksAttributeID]BloksTreeScript{},
 		}
@@ -298,10 +399,18 @@ func (btn *BloksTreeNode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (btn *BloksTreeNode) Redact() {
+	if btn == nil {
+		return
+	}
+	btn.BloksTreeNodeContent.Redact()
+}
+
 type BloksTreeNodeContent interface {
 	Unminify(m *Unminifier, parent *BloksTreeComponent)
-	Print(prefix string) error
-	PrintHTML(prefix string) error
+	Print(w io.Writer, prefix string) error
+	PrintHTML(w io.Writer, prefix string) error
+	Redact()
 }
 
 type BloksTreeComponent struct {
@@ -359,8 +468,8 @@ func (btc *BloksTreeComponent) Unminify(m *Unminifier, parent *BloksTreeComponen
 	}
 }
 
-func (btc *BloksTreeComponent) Print(indent string) error {
-	fmt.Printf("%s<Component name=%s>\n", indent, btc.ComponentID)
+func (btc *BloksTreeComponent) Print(w io.Writer, indent string) error {
+	fmt.Fprintf(w, "%s<Component name=%s>\n", indent, btc.ComponentID)
 	attrs := []BloksAttributeID{}
 	for attr := range btc.Attributes {
 		attrs = append(attrs, attr)
@@ -387,14 +496,14 @@ func (btc *BloksTreeComponent) Print(indent string) error {
 		default:
 			panic("missing case in bloks tree switch")
 		}
-		fmt.Printf("%s  <Property %s type=%s%s>\n", indent, id.ToTag(), attrtype, extra)
-		err := value.BloksTreeNodeContent.Print(indent + "    ")
+		fmt.Fprintf(w, "%s  <Property %s type=%s%s>\n", indent, id.ToTag(), attrtype, extra)
+		err := value.BloksTreeNodeContent.Print(w, indent+"    ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s%s  </Property %s type=%s%s>\n", trailer, indent, id.ToTag(), attrtype, extra)
+		fmt.Fprintf(w, "%s%s  </Property %s type=%s%s>\n", trailer, indent, id.ToTag(), attrtype, extra)
 	}
-	fmt.Printf("%s</Component name=%s>\n", indent, btc.ComponentID)
+	fmt.Fprintf(w, "%s</Component name=%s>\n", indent, btc.ComponentID)
 	return nil
 }
 
@@ -430,63 +539,69 @@ func (btc *BloksTreeComponent) getCSS() map[string]string {
 	return css
 }
 
-func (btc *BloksTreeComponent) PrintHTML(indent string) error {
+func (btc *BloksTreeComponent) PrintHTML(w io.Writer, indent string) error {
 	switch btc.ComponentID {
 	case "bk.cds.bottomsheet.Wrapper":
-		fmt.Printf("%s<div class=\"%s\">\n", indent, btc.ComponentID)
-		fmt.Printf("%s  <div class=\"header\">\n", indent)
-		err := btc.Attributes["header"].PrintHTML(indent + "    ")
+		fmt.Fprintf(w, "%s<div class=\"%s\">\n", indent, btc.ComponentID)
+		fmt.Fprintf(w, "%s  <div class=\"header\">\n", indent)
+		err := btc.Attributes["header"].PrintHTML(w, indent+"    ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s  </div>\n", indent)
-		fmt.Printf("%s  <div class=\"content\">\n", indent)
-		err = btc.Attributes["content"].PrintHTML(indent + "    ")
+		fmt.Fprintf(w, "%s  </div>\n", indent)
+		fmt.Fprintf(w, "%s  <div class=\"content\">\n", indent)
+		err = btc.Attributes["content"].PrintHTML(w, indent+"    ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s  </div>\n", indent)
-		fmt.Printf("%s</div>\n", indent)
+		fmt.Fprintf(w, "%s  </div>\n", indent)
+		fmt.Fprintf(w, "%s</div>\n", indent)
 	case "bk.components.Flexbox":
 		css := btc.getCSS()
 		css["align-items"] = btc.GetAttribute("align_items")
 		css["flex-direction"] = btc.GetAttribute("flex_direction")
 		css["justify-content"] = btc.GetAttribute("justify_content")
-		fmt.Printf("%s<div class=\"%s\" style=\"%s\">\n", indent, btc.ComponentID, cssToString(css))
-		err := btc.Attributes["children"].PrintHTML(indent + "  ")
+		fmt.Fprintf(w, "%s<div class=\"%s\" style=\"%s\">\n", indent, btc.ComponentID, cssToString(css))
+		err := btc.Attributes["children"].PrintHTML(w, indent+"  ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s</div>\n", indent)
+		fmt.Fprintf(w, "%s</div>\n", indent)
 	case "bk.components.Collection":
 		css := btc.getCSS()
-		fmt.Printf("%s<div class=\"%s\" style=\"%s\">\n", indent, btc.ComponentID, cssToString(css))
-		err := btc.Attributes["children"].PrintHTML(indent + "  ")
+		fmt.Fprintf(w, "%s<div class=\"%s\" style=\"%s\">\n", indent, btc.ComponentID, cssToString(css))
+		err := btc.Attributes["children"].PrintHTML(w, indent+"  ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s</div>\n", indent)
+		fmt.Fprintf(w, "%s</div>\n", indent)
 	case "bk.components.RichText", "bk.data.ComposableTextSpan":
-		fmt.Printf("%s<div class=\"%s\">\n", indent, btc.ComponentID)
-		err := btc.Attributes["spans"].PrintHTML(indent + "  ")
+		fmt.Fprintf(w, "%s<div class=\"%s\">\n", indent, btc.ComponentID)
+		err := btc.Attributes["spans"].PrintHTML(w, indent+"  ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s</div>\n", indent)
+		fmt.Fprintf(w, "%s</div>\n", indent)
 	case "bk.data.TextSpan":
-		fmt.Printf("%s<span>%s</span>\n", indent, btc.GetAttribute("text"))
+		fmt.Fprintf(w, "%s<span>%s</span>\n", indent, btc.GetAttribute("text"))
 	case "bk.components.TextInput":
-		fmt.Printf("%s<input type=\"%s\" placeholder=\"%s\">\n", indent, btc.GetAttribute("type"), btc.GetAttribute("placeholder"))
+		fmt.Fprintf(w, "%s<input type=\"%s\" placeholder=\"%s\">\n", indent, btc.GetAttribute("type"), btc.GetAttribute("placeholder"))
 	case "bk.components.Image":
-		fmt.Printf("%s<img id=\"%s\" src=\"%s\">\n", indent, btc.GetAttribute("unique_id"), btc.GetAttribute("url"))
+		fmt.Fprintf(w, "%s<img id=\"%s\" src=\"%s\">\n", indent, btc.GetAttribute("unique_id"), btc.GetAttribute("url"))
 	default:
 		attrs := []BloksAttributeID{}
 		for attr := range btc.Attributes {
 			attrs = append(attrs, attr)
 		}
-		fmt.Printf("%s<!-- component %s omitted (props %+v) -->\n", indent, btc.ComponentID, attrs)
+		fmt.Fprintf(w, "%s<!-- component %s omitted (props %+v) -->\n", indent, btc.ComponentID, attrs)
 	}
 	return nil
+}
+
+func (btc *BloksTreeComponent) Redact() {
+	for _, child := range btc.Attributes {
+		child.Redact()
+	}
 }
 
 type BloksTreeComponentList []*BloksTreeComponent
@@ -519,9 +634,9 @@ func (btcl *BloksTreeComponentList) Unminify(m *Unminifier, parent *BloksTreeCom
 	}
 }
 
-func (btcl BloksTreeComponentList) Print(indent string) error {
+func (btcl BloksTreeComponentList) Print(w io.Writer, indent string) error {
 	for _, comp := range btcl {
-		err := comp.Print(indent)
+		err := comp.Print(w, indent)
 		if err != nil {
 			return err
 		}
@@ -529,40 +644,50 @@ func (btcl BloksTreeComponentList) Print(indent string) error {
 	return nil
 }
 
-func (btcl *BloksTreeComponentList) PrintHTML(indent string) error {
+func (btcl *BloksTreeComponentList) PrintHTML(w io.Writer, indent string) error {
 	for _, comp := range *btcl {
-		err := comp.PrintHTML(indent)
+		err := comp.PrintHTML(w, indent)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (btcl *BloksTreeComponentList) Redact() {
+	for _, comp := range *btcl {
+		comp.Redact()
+	}
 }
 
 type BloksTreeLiteral struct {
-	BloksJavascriptValue
+	BloksJavaScriptValue
 }
 
 func (btl *BloksTreeLiteral) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &btl.BloksJavascriptValue)
+	return json.Unmarshal(data, &btl.BloksJavaScriptValue)
 }
 
 func (btl *BloksTreeLiteral) Unminify(m *Unminifier, parent *BloksTreeComponent) {
 	//
 }
 
-func (btl *BloksTreeLiteral) Print(indent string) error {
-	str, err := json.Marshal(btl.BloksJavascriptValue)
+func (btl *BloksTreeLiteral) Print(w io.Writer, indent string) error {
+	str, err := json.Marshal(btl.BloksJavaScriptValue)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s%s\n", indent, str)
+	fmt.Fprintf(w, "%s%s\n", indent, str)
 	return nil
 }
 
-func (btl *BloksTreeLiteral) PrintHTML(indent string) error {
-	fmt.Printf("%s<!-- literal omitted -->\n", indent)
+func (btl *BloksTreeLiteral) PrintHTML(w io.Writer, indent string) error {
+	fmt.Fprintf(w, "%s<!-- literal omitted -->\n", indent)
 	return nil
+}
+
+func (btl *BloksTreeLiteral) Redact() {
+	redactJavaScriptValue((*any)(&btl.BloksJavaScriptValue))
 }
 
 type BloksTreeScript struct {
@@ -591,13 +716,20 @@ func (bst *BloksTreeScript) Parse(code string) error {
 	return err
 }
 
-func (bst *BloksTreeScript) Print(indent string) error {
-	return bst.AST.Print(indent)
+func (bst *BloksTreeScript) Print(w io.Writer, indent string) error {
+	return bst.AST.Print(w, indent)
 }
 
-func (bst *BloksTreeScript) PrintHTML(indent string) error {
-	fmt.Printf("%s<!-- script omitted -->\n", indent)
+func (bst *BloksTreeScript) PrintHTML(w io.Writer, indent string) error {
+	fmt.Fprintf(w, "%s<!-- script omitted -->\n", indent)
 	return nil
+}
+
+func (bst *BloksTreeScript) Redact() {
+	if bst == nil {
+		return
+	}
+	bst.AST.Redact()
 }
 
 type BloksTreeScriptSet struct {
@@ -619,7 +751,7 @@ func (bst *BloksTreeScriptSet) Unminify(m *Unminifier, parent *BloksTreeComponen
 	}
 }
 
-func (bst *BloksTreeScriptSet) Print(indent string) error {
+func (bst *BloksTreeScriptSet) Print(w io.Writer, indent string) error {
 	ids := []BloksAttributeID{}
 	for id := range bst.Scripts {
 		ids = append(ids, id)
@@ -627,17 +759,25 @@ func (bst *BloksTreeScriptSet) Print(indent string) error {
 	slices.Sort(ids)
 	for _, id := range ids {
 		script := bst.Scripts[id]
-		fmt.Printf("%s<Script %s>\n", indent, id.ToTag())
-		err := script.Print(indent + "  ")
+		fmt.Fprintf(w, "%s<Script %s>\n", indent, id.ToTag())
+		err := script.Print(w, indent+"  ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf("\n%s</Script %s>\n", indent, id.ToTag())
+		fmt.Fprintf(w, "\n%s</Script %s>\n", indent, id.ToTag())
 	}
 	return nil
 }
 
-func (bst *BloksTreeScriptSet) PrintHTML(indent string) error {
-	fmt.Printf("%s<!-- script set omitted -->\n", indent)
+func (bst *BloksTreeScriptSet) PrintHTML(w io.Writer, indent string) error {
+	fmt.Fprintf(w, "%s<!-- script set omitted -->\n", indent)
 	return nil
+}
+
+func (bst *BloksTreeScriptSet) Redact() {
+	for key := range bst.Scripts {
+		scr := bst.Scripts[key]
+		scr.Redact()
+		bst.Scripts[key] = scr
+	}
 }

--- a/pkg/messagix/bloks/tree.go
+++ b/pkg/messagix/bloks/tree.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"regexp"
 	"slices"
 	"strconv"
@@ -220,22 +221,80 @@ type BloksDatumInfo struct {
 type BloksJavaScriptValue any
 
 var likelyNonSensitive = regexp.MustCompile(strings.Join([]string{
-	// attr name like "extra_client_data_bks_input" or "should_trigger_override_login_2fa_action"
-	`^[a-z2]{2,12}(_[a-z2]{2,12})+$`,
-	// english sentence or display name
-	`^[A-Za-z']{1,12}( [A-Za-z']{1,12}[.,]?)+ *$`,
 	// clearly internal identifiers
 	`^com.bloks.`,
 	`^(CAA|caa|INTERNAL)_`,
 	`^i:(caa|com\.bloks)\.`,
+	// floating-point number
+	`^[0-9]{1,3}\.[0-9]{1,16}dp$`,
+}, `|`))
+
+var likelyNonSensitiveURLPath = regexp.MustCompile(strings.Join([]string{
 	// cdn url, not user specific
 	`^rsrc.php/`,
 }, `|`))
 
+var englishWord = regexp.MustCompile(`([A-Za-z0-9'-]+)[,.:;]? *`)
+var digitRegexp = regexp.MustCompile(`[0-9]`)
+var lowercaseLetterRegexp = regexp.MustCompile(`[a-z]`)
+var uppercaseLetterRegexp = regexp.MustCompile(`[A-Z]`)
+var alnumsRegexp = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+
+func likelyEnglishSentence(s string) bool {
+	words := englishWord.FindAllStringSubmatch(s, -1)
+	numReasonableChars := 0
+	for _, wordMatch := range words {
+		wordAndExtra := wordMatch[0]
+		word := wordMatch[1]
+		if len(word) > 24 {
+			continue
+		}
+		if strings.Count(word, "-") > 1 {
+			continue
+		}
+		if strings.Count(word, "'") > 1 {
+			continue
+		}
+		if len(digitRegexp.FindAllString(word, -1)) > 6 {
+			continue
+		}
+		if len(lowercaseLetterRegexp.FindAllString(word, -1)) > 2 && len(uppercaseLetterRegexp.FindAllString(word, -1)) > 2 {
+			continue
+		}
+		numReasonableChars += len(wordAndExtra)
+	}
+	return float64(numReasonableChars)/float64(len(s)) > 0.8 || len(s)-numReasonableChars < 10
+}
+
+func likelyAttributeName(s string) bool {
+	for _, delimiter := range []string{"-", "_"} {
+		bad := false
+		for part := range strings.SplitSeq(s, delimiter) {
+			if len(part) > 24 {
+				bad = true
+			}
+			if !alnumsRegexp.MatchString(part) {
+				bad = true
+			}
+			if len(digitRegexp.FindAllString(part, -1)) > 2 {
+				bad = true
+			}
+			if len(lowercaseLetterRegexp.FindAllString(part, -1)) > 2 && len(uppercaseLetterRegexp.FindAllString(part, -1)) > 2 {
+				bad = true
+			}
+		}
+		if !bad {
+			return true
+		}
+	}
+	return false
+}
+
 var stringTypes = map[string]*regexp.Regexp{
 	"uuid_lowercase": regexp.MustCompile(`^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}`),
 	"uuid_uppercase": regexp.MustCompile(`^[0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12}`),
-	"hex":            regexp.MustCompile(`^[0-9a-f]+$`),
+	"hex":            regexp.MustCompile(`^[0-9a-f]*[a-f][0-9a-f]*$`),
+	"number":         regexp.MustCompile(`^[0-9]+$`),
 }
 
 var likelyURL = regexp.MustCompile(`^([a-z]{2,10}://[a-z0-9.-]+/)(.+)$`)
@@ -253,10 +312,16 @@ func redactString(s string) string {
 			return string(out)
 		}
 	}
-	if len(s) < 20 {
+	if len(s) < 16 {
 		return s
 	}
 	if likelyNonSensitive.MatchString(s) {
+		return s
+	}
+	if likelyAttributeName(s) {
+		return s
+	}
+	if likelyEnglishSentence(s) {
 		return s
 	}
 	prefix := ""
@@ -264,7 +329,7 @@ func redactString(s string) string {
 		prefix = match[1]
 		s = match[2]
 	}
-	if likelyNonSensitive.MatchString(s) {
+	if likelyNonSensitiveURLPath.MatchString(s) {
 		return prefix + s
 	}
 	stringType := "str"
@@ -278,10 +343,42 @@ func redactString(s string) string {
 	return fmt.Sprintf("%sredacted_%dchar_%s_%s", prefix, len(s), stringType, hex.EncodeToString(digest[:4]))
 }
 
+// Integers can only have 10 significant figures before it might start
+// being the case that they are communicating sensitive data. Allowing
+// for 10 to accommodate seconds-since-epoch timestamps.
+const maxRedactedSigFigs = 10
+
+func redactInteger(num int64) int64 {
+	mag := math.Log10(math.Abs(float64(num)))
+	if mag <= maxRedactedSigFigs {
+		return num
+	}
+	factor := int64(math.Pow10(int(math.Ceil(mag) - maxRedactedSigFigs)))
+	num /= factor
+	num *= factor
+	return num
+}
+
+func redactFloat(num float64) float64 {
+	mag := math.Log10(math.Abs(num))
+	if mag <= maxRedactedSigFigs {
+		return num
+	}
+	factor := math.Pow10(int(math.Ceil(mag) - maxRedactedSigFigs))
+	num /= factor
+	num = math.Round(num)
+	num *= factor
+	return num
+}
+
 func redactJavaScriptValue(ptr *any) {
 	switch val := (*ptr).(type) {
 	case string:
 		*ptr = redactString(val)
+	case int64:
+		*ptr = redactInteger(val)
+	case float64:
+		*ptr = redactFloat(val)
 	case []any:
 		for idx := range val {
 			redactJavaScriptValue(&val[idx])

--- a/pkg/messagix/client.go
+++ b/pkg/messagix/client.go
@@ -35,8 +35,9 @@ var ErrClientIsNil = whatsmeow.ErrClientIsNil
 type EventHandler func(ctx context.Context, evt any)
 
 type Config struct {
-	MayConnectToDGW bool
-	ClientSettings  exhttp.ClientSettings
+	MayConnectToDGW          bool
+	ClientSettings           exhttp.ClientSettings
+	LogRedactedBloksPayloads bool
 }
 
 type Client struct {
@@ -74,6 +75,8 @@ type Client struct {
 	stopCurrentConnections atomic.Pointer[context.CancelFunc]
 	connectionLoopStopped  *exsync.Event
 	canSendMessages        *exsync.Event
+
+	logRedactedBloksPayloads bool
 }
 
 var DisableTLSVerification = false
@@ -84,13 +87,14 @@ func NewClient(cookies *cookies.Cookies, logger zerolog.Logger, cfg *Config) *Cl
 		panic("messagix: platform must be set in cookies")
 	}
 	cli := &Client{
-		cookies:               cookies,
-		Logger:                logger,
-		lsRequests:            0,
-		graphQLRequests:       1,
-		Platform:              cookies.Platform,
-		connectionLoopStopped: exsync.NewEvent(),
-		canSendMessages:       exsync.NewEvent(),
+		cookies:                  cookies,
+		Logger:                   logger,
+		lsRequests:               0,
+		graphQLRequests:          1,
+		Platform:                 cookies.Platform,
+		connectionLoopStopped:    exsync.NewEvent(),
+		canSendMessages:          exsync.NewEvent(),
+		logRedactedBloksPayloads: cfg.LogRedactedBloksPayloads,
 	}
 	cli.nextTaskID.Store(-1) // start from 0
 	cli.SetHTTP(cfg.ClientSettings)

--- a/pkg/messagix/graphql.go
+++ b/pkg/messagix/graphql.go
@@ -117,6 +117,18 @@ func (c *Client) MakeBloksRequest(ctx context.Context, doc *bloks.BloksDoc, vari
 		return nil, fmt.Errorf("parsing inner bloks payload: %w", err)
 	}
 
+	if c.logRedactedBloksPayloads {
+		var redactedRespInner bloks.BloksBundle
+		err = json.Unmarshal([]byte(innerData), &redactedRespInner)
+		if err != nil {
+			return nil, fmt.Errorf("second time parsing inner bloks payload: %w", err)
+		}
+		redactedRespInner.Redact()
+		redacted := bytes.Buffer{}
+		redactedRespInner.Print(&redacted, "")
+		c.Logger.Debug().Str("bloks_app", appID).Bytes("resp", redacted.Bytes()).Msg("Logging redacted Bloks response")
+	}
+
 	return &respInner, nil
 }
 

--- a/pkg/messagix/graphql.go
+++ b/pkg/messagix/graphql.go
@@ -2,6 +2,7 @@ package messagix
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -126,7 +127,18 @@ func (c *Client) MakeBloksRequest(ctx context.Context, doc *bloks.BloksDoc, vari
 		redactedRespInner.Redact()
 		redacted := bytes.Buffer{}
 		redactedRespInner.Print(&redacted, "")
-		c.Logger.Debug().Str("bloks_app", appID).Bytes("resp", redacted.Bytes()).Msg("Logging redacted Bloks response")
+		compressed := bytes.Buffer{}
+		compressor := gzip.NewWriter(&compressed)
+		_, err = compressor.Write(redacted.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("compressing redacted bloks payload: %w", err)
+		}
+		err = compressor.Close()
+		if err != nil {
+			return nil, fmt.Errorf("compressing redacted bloks payload: %w", err)
+		}
+		enc := base64.StdEncoding.AppendEncode(nil, compressed.Bytes())
+		c.Logger.Debug().Str("bloks_app", appID).Bytes("resp_gz", enc).Msg("Logging redacted Bloks response")
 	}
 
 	return &respInner, nil


### PR DESCRIPTION
* New config option `network.log_redacted_bloks_payloads`. When enabled, log the Bloks payloads at debug level rather than just trace, but do it in redacted form.
* New framework for doing the redaction. The way it works is a recursive `.Redact()` method that you call to replace all sensitive identifiers in-place, then you `.Print()` as before.
* Update `.Print()` to take an `io.Writer` so that printing to a string is possible.
* Renamed `BloksJavascriptValue` to capitalize properly `BloksJavaScriptValue`.
* Fixed a bug where JS literals were printed with some bogus fields generated by Golang, because we weren't calling `.Flatten()` properly before marshaling them.
* New `-redact` option to the cmdline tool, to test the redaction framework easily. Analogous to `-print`. Accept `-` as a value for `-filename`, to read from stdin per UNIX conventions.
* Replaced `BloksJavaScriptValue` with new type alias `BloksScriptLiteralValue` as the field type in `BloksScriptLiteral`. Previously we were reusing `BloksJavaScriptValue` between both the script literal context and the actual JS literal context, despite their having materially different internal formats within the `any`, and converter functions for going between them. Now the typing makes it clear which internal structure to expect depending on context.

Redaction framework:
* Heuristics based on Bloks scripting. Certain functions are only ever passed nonsensitive data in certain argument positions. If those arguments are string literals, they're left alone.
* Heuristics based on known-safe patterns within string literals, for example ones that start with `com.bloks` or static CDN URLs.
* Heuristics for detecting what are likely to be English sentences or coding identifiers, based on approximate symbol composition rather than a heavier dictionary/entropy-based approach. Works very well in practice.
* Replace redacted strings with sha256 hash of their contents, and include length+formatting information.
* Redact long integers by zeroing out everything past the first 10 significant digits, to avoid capturing credentials or tokens represented as integers.
* Traverse into string literals that appear to contain stringified JSON objects, to redact more precisely. Due to Golang limitations, this can reorder field names.

Design decision: redaction framework applies _after_ parsing and unminification, because that's when we have rich typing information available to inform the redaction. There's no way to re-minify, and formatting won't be preserved perfectly, unlike the existing payload trace logs which are dumped before parsing.

Design decision: redaction framework operates in-place, and there's no way to make a copy. What you do is just parse the raw payload string twice and then redact one of them. The implementation is way simpler this way and the performance implication is really not that significant, plus this is only a debugging feature.

Design decision: gzip and base64-encode redacted payload before logging. Some payloads can be as large as 1MB, totally inappropriate for a log line. gzip compression reduces that to 50KB, which is still bad but is a lot better.
