### PR TITLE
Fetch full XMA media after embedded URL download failure

### DIFF
--- a/pkg/msgconv/from-meta.go
+++ b/pkg/msgconv/from-meta.go
@@ -848,7 +848,7 @@ func (mc *MessageConverter) xmaAttachmentToMatrix(ctx context.Context, att *tabl
 		}}
 	} else if err != nil {
 		zerolog.Ctx(ctx).Err(err).Msg("Failed to transfer XMA media")
-		converted = errorToNotice(err, "XMA")
+		converted = mc.fetchFullXMA(ctx, att, errorToNotice(err, "XMA"))
 	} else {
 		converted = mc.fetchFullXMA(ctx, att, converted)
 	}


### PR DESCRIPTION
Fix XMA media conversion when the embedded media URL is stale.

Instagram posts and reels can contain embedded signed CDN URLs that expire. The converter currently tries to download that embedded URL first, and only calls fetchFullXMA after that download succeeds, so if the embedded URL is stale, the bridge gives up before reaching fetchFullXMA, even though fetchFullXMA can independently ask the Instagram API for fresh media data and a new downloadable media URL.

This fixes the failed embedded-download path to call fetchFullXMA too, using the existing notice as the fallback.

The existing fallback behavior is preserved: if XMA fetching is disabled, or if the fresh fetch/reupload also fails, fetchFullXMA returns the notice.