### PR TITLE
messagix/bloks: Allow roundtrip export for parser

### DIFF
--- a/pkg/messagix/bloks/cmd/main.go
+++ b/pkg/messagix/bloks/cmd/main.go
@@ -25,6 +25,7 @@ import (
 var filename = flag.String("file", "", "Bloks response to parse")
 var doPrint = flag.Bool("print", false, "Pretty-print the bundle")
 var doRedact = flag.Bool("redact", false, "Pretty-print the bundle but in redacted form")
+var doExport = flag.Bool("export", false, "Print the bundle in a format that can be parsed again")
 var doHTML = flag.Bool("html", false, "Print as HTML")
 var doLogin = flag.Bool("login", false, "Click the login button")
 var do2FA = flag.String("2fa", "", "Submit a two-factor code")
@@ -150,6 +151,15 @@ func mainE() error {
 	if *doRedact {
 		bundle.Redact()
 		return bundle.Print(os.Stdout, "")
+	}
+	if *doExport {
+		out, err := json.Marshal(bundle)
+		if err != nil {
+			return err
+		}
+		os.Stdout.Write(out)
+		fmt.Println()
+		return nil
 	}
 	if *doHTML {
 		return bundle.PrintHTML(os.Stdout, "")

--- a/pkg/messagix/bloks/tree.go
+++ b/pkg/messagix/bloks/tree.go
@@ -1,6 +1,7 @@
 package bloks
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -15,6 +16,14 @@ import (
 )
 
 type BloksBundle struct {
+	Layout      BloksLayout  `json:"layout"`
+	Interpreter *Interpreter `json:"-"`
+}
+
+// same as BloksBundle but doesn't have json methods defined, so that we can do
+// pre/post-processing and then call back to the normal json methods without
+// entering an infinite loop
+type fakeBloksBundle struct {
 	Layout      BloksLayout  `json:"layout"`
 	Interpreter *Interpreter `json:"-"`
 }
@@ -40,21 +49,27 @@ func (bb *BloksBundle) SetupInterpreter(ctx context.Context, br *InterpBridge, p
 }
 
 func (bb *BloksBundle) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Layout      BloksLayout  `json:"layout"`
-		Interpreter *Interpreter `json:"-"`
-	}
+	var raw fakeBloksBundle
 	err := json.Unmarshal(data, &raw)
 	if err != nil {
 		return err
 	}
-	*bb = raw
+	*bb = BloksBundle(raw)
 	m, err := GetUnminifier(bb)
 	if err != nil {
 		return err
 	}
 	bb.Unminify(m)
 	return nil
+}
+
+func (bb *BloksBundle) MarshalJSON() ([]byte, error) {
+	copy := *bb
+	pay := &copy.Layout.Payload
+	if pay.VariablesOwner != &bb.Layout.Payload {
+		pay.Variables = nil
+	}
+	return json.Marshal((*fakeBloksBundle)(&copy))
 }
 
 func (bb *BloksBundle) Unminify(m *Unminifier) {
@@ -194,9 +209,9 @@ type BloksLayout struct {
 type BloksPayload struct {
 	Scripts             map[BloksScriptID]BloksTreeScript `json:"ft"`
 	ReferencedVariables []BloksVariableID                 `json:"referenced"`
-	ReferencePayloads   []BloksPayloadID                  `json:"referenced_embedded_payload"`
+	ReferencedPayloads  []BloksPayloadID                  `json:"referenced_embedded_payload"`
 	Variables           []*BloksVariable                  `json:"data"`
-	VariablesOwner      *BloksPayload
+	VariablesOwner      *BloksPayload                     `json:"-"`
 	Embedded            []*BloksEmbeddedPayload           `json:"embedded_payloads"`
 	Props               []BloksProp                       `json:"props"`
 	Templates           map[BloksTemplateID]BloksTreeNode `json:"templates"`
@@ -494,6 +509,35 @@ func (btn *BloksTreeNode) UnmarshalJSON(data []byte) error {
 	}
 	btn.BloksTreeNodeContent = &literal
 	return nil
+}
+
+func (btn BloksTreeNode) MarshalJSON() ([]byte, error) {
+	switch node := btn.BloksTreeNodeContent.(type) {
+	case *BloksTreeComponent:
+		return json.Marshal(map[BloksComponentID]any{
+			node.ComponentID: node.Attributes,
+		})
+	case *BloksTreeComponentList:
+		comps := []any{}
+		for _, comp := range *node {
+			comps = append(comps, map[BloksComponentID]any{
+				comp.ComponentID: comp.Attributes,
+			})
+		}
+		return json.Marshal(comps)
+	case *BloksTreeLiteral:
+		return json.Marshal(node.BloksJavaScriptValue)
+	case *BloksTreeScript:
+		return json.Marshal(node)
+	case *BloksTreeScriptSet:
+		data := []any{}
+		for prop, script := range node.Scripts {
+			data = append(data, prop, script)
+		}
+		return json.Marshal(data)
+	default:
+		return nil, fmt.Errorf("unexpected node type during marshal %T", node)
+	}
 }
 
 func (btn *BloksTreeNode) Redact() {
@@ -802,6 +846,17 @@ func (bs *BloksTreeScript) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("script: %w", err)
 	}
 	return nil
+}
+
+var indentRegexp = regexp.MustCompile(`\n?BLOKS_INDENT *`)
+
+func (bs BloksTreeScript) MarshalJSON() ([]byte, error) {
+	out := bytes.Buffer{}
+	err := bs.Print(&out, "BLOKS_INDENT")
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal("\t" + indentRegexp.ReplaceAllString(out.String(), " "))
 }
 
 func (bs *BloksTreeScript) Unminify(m *Unminifier, parent *BloksTreeComponent) {

--- a/pkg/messagix/graphql.go
+++ b/pkg/messagix/graphql.go
@@ -125,11 +125,10 @@ func (c *Client) MakeBloksRequest(ctx context.Context, doc *bloks.BloksDoc, vari
 			return nil, fmt.Errorf("second time parsing inner bloks payload: %w", err)
 		}
 		redactedRespInner.Redact()
-		redacted := bytes.Buffer{}
-		redactedRespInner.Print(&redacted, "")
+		redacted, err := json.Marshal(redactedRespInner)
 		compressed := bytes.Buffer{}
 		compressor := gzip.NewWriter(&compressed)
-		_, err = compressor.Write(redacted.Bytes())
+		_, err = compressor.Write(redacted)
 		if err != nil {
 			return nil, fmt.Errorf("compressing redacted bloks payload: %w", err)
 		}

--- a/pkg/messagix/graphql.go
+++ b/pkg/messagix/graphql.go
@@ -126,6 +126,9 @@ func (c *Client) MakeBloksRequest(ctx context.Context, doc *bloks.BloksDoc, vari
 		}
 		redactedRespInner.Redact()
 		redacted, err := json.Marshal(redactedRespInner)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling redacted bloks payload: %w", err)
+		}
 		compressed := bytes.Buffer{}
 		compressor := gzip.NewWriter(&compressed)
 		_, err = compressor.Write(redacted)


### PR DESCRIPTION
Implement MarshalJSON for the Bloks structs. Similar to UnmarshalJSON, which sort-of does JSON decoding but also does a bunch of other pre- and post-processing to fix up Facebook's weird JSON into something reasonable, the MarshalJSON undoes those transformations, such that the output can be re-input to the parser and you get the same result.

It's really quite simple, because most of the transformations don't have to be undone: they are either internal details of the structs that are filtered out by default when marshaling, or they are unminification that we don't have to reverse since the parser can already handle parsing unminified data just as well as minified data.

The main gross hack you'll notice here is my using a special token to help generate Lisp output that isn't as verbose with whitespace, without having to thread awareness of that through all the Lisp structs, and just doing a string find-and-replace after the fact. Feel free to replace with a less ass version.

The reason for this feature is so that the logging from #270 will be in a format that you can actually parse with the Bloks command-line utility.
