### PR TITLE
messagix/bloks: Much better flow graph impl

### DIFF
--- a/pkg/messagix/bloks/cmd/main.go
+++ b/pkg/messagix/bloks/cmd/main.go
@@ -184,7 +184,7 @@ func mainE() error {
 			}
 			fmt.Printf("%s\n", string(payload))
 			return &bloks.BloksScriptNode{
-				BloksScriptNodeContent: bloks.BloksNull,
+				Content: bloks.BloksNull,
 			}, nil
 		},
 		HandleLoginResponse: func(ctx context.Context, data string) error {

--- a/pkg/messagix/bloks/cmd/main.go
+++ b/pkg/messagix/bloks/cmd/main.go
@@ -45,6 +45,7 @@ var doBackupCode = flag.String("backup-code", "", "Submit backup code")
 var doEncrypt = flag.String("encrypt", "", "Encrypt a password")
 var deviceID = flag.String("device-id", "", "Device ID for password encryption")
 var doCaptcha = flag.String("captcha-code", "", "Captcha code to submit")
+var captchaResponse = flag.String("captcha-resp", "", "Bloks response for captcha submission")
 
 func main() {
 	err := mainE()
@@ -183,6 +184,14 @@ func mainE() error {
 				return nil, err
 			}
 			fmt.Printf("%s\n", string(payload))
+			if *captchaResponse != "" {
+				bundle, err := readAndParse[bloks.BloksBundle](*captchaResponse)
+				if err != nil {
+					return nil, err
+				}
+				fmt.Printf("(providing response from %s)\n", *captchaResponse)
+				return bundle.Action(), nil
+			}
 			return &bloks.BloksScriptNode{
 				Content: bloks.BloksNull,
 			}, nil
@@ -205,6 +214,10 @@ func mainE() error {
 				return fmt.Errorf("already opened a url this session")
 			}
 			lastURL = url
+			return nil
+		},
+		HandleVariableChange: func(ctx context.Context, name string, value *bloks.BloksScriptLiteral) error {
+			log.Trace().Str("variable", name).Any("value", value.Flatten(false)).Msg("Handling variable value change")
 			return nil
 		},
 	}
@@ -457,35 +470,43 @@ func mainE() error {
 			}
 		}
 	} else if *captcha {
-		img := bundle.FindDescendant(bloks.FilterByAttribute("bk.components.Image", "unique_id", "i:com.bloks.www.two_step_verification.enter_text_captcha_code/p:captcha_image"))
-		if img == nil {
-			return fmt.Errorf("can't find captcha image")
+		getURLs := func() (string, string, error) {
+			img := bundle.FindDescendant(bloks.FilterByAttribute("bk.components.Image", "unique_id", "i:com.bloks.www.two_step_verification.enter_text_captcha_code/p:captcha_image"))
+			if img == nil {
+				return "", "", fmt.Errorf("can't find captcha image")
+			}
+			imageURL := img.GetDynamicAttribute(ctx, interp, "url")
+			if imageURL == "" {
+				return "", "", fmt.Errorf("captcha image has no url")
+			}
+			audio := bundle.FindDescendant(bloks.FilterByAttribute("bk.data.TextSpan", "text", "play audio"))
+			if audio == nil {
+				return "", "", fmt.Errorf("can't find audio text")
+			}
+			clickable := audio.FindDescendant(bloks.FilterByComponent("bk.style.textspan.ClickableStyle"))
+			if clickable == nil {
+				return "", "", fmt.Errorf("audio text is not clickable")
+			}
+			onClick := clickable.GetScript("on_click")
+			if onClick == nil {
+				return "", "", fmt.Errorf("no on_click on audio text")
+			}
+			_, err := interp.Evaluate(ctx, &onClick.AST)
+			if err != nil {
+				return "", "", fmt.Errorf("clicking on audio text: %w", err)
+			}
+			if lastURL == "" {
+				return "", "", fmt.Errorf("clicking on audio text failed to open url")
+			}
+			audioURL := strings.Replace(lastURL, "/player/", "/", 1)
+			lastURL = ""
+			return imageURL, audioURL, nil
 		}
-		imageURL := img.GetDynamicAttribute(ctx, interp, "url")
-		if imageURL == "" {
-			return fmt.Errorf("captcha image has no url")
+		imageURL, audioURL, err := getURLs()
+		if err != nil {
+			return err
 		}
 		fmt.Println("Image:", imageURL)
-		audio := bundle.FindDescendant(bloks.FilterByAttribute("bk.data.TextSpan", "text", "play audio"))
-		if audio == nil {
-			return fmt.Errorf("can't find audio text")
-		}
-		clickable := audio.FindDescendant(bloks.FilterByComponent("bk.style.textspan.ClickableStyle"))
-		if clickable == nil {
-			return fmt.Errorf("audio text is not clickable")
-		}
-		onClick := clickable.GetScript("on_click")
-		if onClick == nil {
-			return fmt.Errorf("no on_click on audio text")
-		}
-		_, err := interp.Evaluate(ctx, &onClick.AST)
-		if err != nil {
-			return fmt.Errorf("clicking on audio text: %w", err)
-		}
-		if lastURL == "" {
-			return fmt.Errorf("clicking on audio text failed to open url")
-		}
-		audioURL := strings.Replace(lastURL, "/player/", "/", 1)
 		fmt.Println("Audio:", audioURL)
 		if *doCaptcha != "" {
 			err := bundle.
@@ -508,6 +529,16 @@ func mainE() error {
 			if err != nil {
 				return fmt.Errorf("tapping continue: %w", err)
 			}
+		}
+		newImageURL, newAudioURL, err := getURLs()
+		if err != nil {
+			return err
+		}
+		if newImageURL != imageURL {
+			fmt.Println("New image:", newImageURL)
+		}
+		if newAudioURL != audioURL {
+			fmt.Println("New audio:", newAudioURL)
 		}
 	} else if *doSMSCode != "" {
 		err := bundle.

--- a/pkg/messagix/bloks/cmd/main.go
+++ b/pkg/messagix/bloks/cmd/main.go
@@ -221,7 +221,7 @@ func mainE() error {
 			return nil
 		},
 	}
-	interp, err := bloks.NewInterpreter(ctx, bundle, &bridge, nil)
+	interp, err := bloks.NewInterpreter(ctx, bundle, &bridge, nil, true)
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func mainE() error {
 		if *doLogin {
 			interp.Bridge.DisplayNewScreen = func(ctx context.Context, name string, newBundle *bloks.BloksBundle) error {
 				bundle = newBundle
-				interp, err = bloks.NewInterpreter(ctx, bundle, &bridge, interp)
+				interp, err = bloks.NewInterpreter(ctx, bundle, &bridge, interp, true)
 				if err != nil {
 					return err
 				}

--- a/pkg/messagix/bloks/cmd/main.go
+++ b/pkg/messagix/bloks/cmd/main.go
@@ -167,14 +167,25 @@ func mainE() error {
 	}
 	lastURL := ""
 	bridge := bloks.InterpBridge{
-		DoRPC: func(ctx context.Context, name string, params map[string]string, isPage bool, callback func(result *bloks.BloksScriptLiteral) error) error {
-			fmt.Printf("%s isPage=%v\n", name, isPage)
+		DoPageRPC: func(ctx context.Context, name string, params map[string]string) (*bloks.BloksBundle, error) {
+			fmt.Printf("%s type=page\n", name)
 			payload, err := json.Marshal(params)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			fmt.Printf("%s\n", string(payload))
-			return nil
+			return nil, nil
+		},
+		DoActionRPC: func(ctx context.Context, name string, params map[string]string) (*bloks.BloksScriptNode, error) {
+			fmt.Printf("%s type=action\n", name)
+			payload, err := json.Marshal(params)
+			if err != nil {
+				return nil, err
+			}
+			fmt.Printf("%s\n", string(payload))
+			return &bloks.BloksScriptNode{
+				BloksScriptNodeContent: bloks.BloksNull,
+			}, nil
 		},
 		HandleLoginResponse: func(ctx context.Context, data string) error {
 			fmt.Printf("%s\n", data)

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -46,7 +46,7 @@ type Interpreter struct {
 	GlobalVars map[BloksVariableID]*BloksScriptLiteral
 }
 
-func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *Interpreter) (*Interpreter, error) {
+func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *Interpreter, clearLocals bool) (*Interpreter, error) {
 	p := b.Layout.Payload
 	scripts := map[BloksScriptID]*BloksLambda{}
 	payloads := map[BloksPayloadID]*BloksBundleRef{}
@@ -83,6 +83,9 @@ func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *
 			globals[id] = BloksLiteralFromJavaScript(item.Info.Initial)
 		case "ls":
 			// Local vars do not carry over between screens
+			if locals[id] != nil && !clearLocals {
+				break
+			}
 			locals[id] = BloksLiteralFromJavaScript(item.Info.Initial)
 		default:
 			return nil, fmt.Errorf("unexpected var type %s", item.Type)

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -216,9 +216,9 @@ func evalAs[T any](ctx context.Context, i *Interpreter, form *BloksScriptNode, w
 }
 
 func evalTreeProp35(ctx context.Context, i *Interpreter, form *BloksScriptNode, where string) (string, error) {
-	make, ok := form.BloksScriptNodeContent.(*BloksScriptFuncall)
+	make, ok := form.Content.(*BloksScriptFuncall)
 	if !ok {
-		return "", fmt.Errorf("%s non-funcall %T", where, form.BloksScriptNodeContent)
+		return "", fmt.Errorf("%s non-funcall %T", where, form.Content)
 	}
 	if make.Function != "bk.action.tree.Make" {
 		return "", fmt.Errorf("%s non-tree funcall %s", where, make.Function)
@@ -246,9 +246,9 @@ func evalTreeProp35(ctx context.Context, i *Interpreter, form *BloksScriptNode, 
 }
 
 func evalTreeCallback(ctx context.Context, i *Interpreter, form *BloksScriptNode, where string) (*BloksLambda, error) {
-	make, ok := form.BloksScriptNodeContent.(*BloksScriptFuncall)
+	make, ok := form.Content.(*BloksScriptFuncall)
 	if !ok {
-		return nil, fmt.Errorf("%s non-funcall %T", where, form.BloksScriptNodeContent)
+		return nil, fmt.Errorf("%s non-funcall %T", where, form.Content)
 	}
 	if make.Function != "bk.action.tree.Make" {
 		return nil, fmt.Errorf("%s non-tree funcall %s", where, make.Function)
@@ -332,16 +332,16 @@ func getBloksType(lit *BloksScriptLiteral) (int64, error) {
 }
 
 func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*BloksScriptLiteral, error) {
-	if lit, ok := form.BloksScriptNodeContent.(*BloksScriptLiteral); ok {
+	if lit, ok := form.Content.(*BloksScriptLiteral); ok {
 		return lit, nil
 	}
 	ambientArgs, ok := ctx.Value(interpCtxArgs).([]*BloksScriptLiteral)
 	if !ok {
 		ambientArgs = make([]*BloksScriptLiteral, maxInterpArgs)
 	}
-	call, ok := form.BloksScriptNodeContent.(*BloksScriptFuncall)
+	call, ok := form.Content.(*BloksScriptFuncall)
 	if !ok {
-		return nil, fmt.Errorf("unexpected script node %T", form.BloksScriptNodeContent)
+		return nil, fmt.Errorf("unexpected script node %T", form.Content)
 	}
 	// Some of the cases in this switch are not needed for any given login. However different
 	// functions get pulled in depending on which API you are talking to, so I left in
@@ -695,9 +695,9 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		// other than looking them up using getvar, it should work the same.
 		return i.Evaluate(ctx, &call.Args[0])
 	case "bk.action.ref.Read":
-		ref, ok := call.Args[0].BloksScriptNodeContent.(*BloksScriptFuncall)
+		ref, ok := call.Args[0].Content.(*BloksScriptFuncall)
 		if !ok {
-			return nil, fmt.Errorf("reading from non-ref %T", call.Args[0].BloksScriptNodeContent)
+			return nil, fmt.Errorf("reading from non-ref %T", call.Args[0].Content)
 		}
 		if ref.Function != "bk.action.bloks.GetVariable2" && ref.Function != "bk.action.bloks.GetVariableWithScope" {
 			return nil, fmt.Errorf("reading from non-ref funcall %s", ref.Function)
@@ -712,9 +712,9 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		}
 		return value, nil
 	case "bk.action.ref.Write":
-		ref, ok := call.Args[0].BloksScriptNodeContent.(*BloksScriptFuncall)
+		ref, ok := call.Args[0].Content.(*BloksScriptFuncall)
 		if !ok {
-			return nil, fmt.Errorf("reading from non-ref %T (for write)", call.Args[0].BloksScriptNodeContent)
+			return nil, fmt.Errorf("reading from non-ref %T (for write)", call.Args[0].Content)
 		}
 		if ref.Function != "bk.action.bloks.GetVariable2" && ref.Function != "bk.action.bloks.GetVariableWithScope" {
 			return nil, fmt.Errorf("reading from non-ref funcall %s (for write)", ref.Function)
@@ -756,13 +756,11 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		}
 		// Evaluate the action and also pass it to the callback
 		_, err = i.Evaluate(ctx, &BloksScriptNode{
-			BloksScriptNodeContent: &BloksScriptFuncall{
+			Content: &BloksScriptFuncall{
 				Function: "bk.action.core.Apply",
 				Args: []BloksScriptNode{{
 					BloksLiteralOf(callback),
-				}, {
-					action,
-				}},
+				}, *action},
 			},
 		})
 		if err != nil {
@@ -825,12 +823,12 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 	case "h9a":
 		// ignore second argument for now, use first & third
 		return i.Evaluate(ctx, &BloksScriptNode{
-			BloksScriptNodeContent: &BloksScriptFuncall{
+			Content: &BloksScriptFuncall{
 				Function: "bk.action.core.Apply",
 				Args: []BloksScriptNode{
 					call.Args[2],
 					{
-						BloksScriptNodeContent: &BloksScriptFuncall{
+						Content: &BloksScriptFuncall{
 							Function: "bk.action.string.EncryptPassword",
 							Args:     []BloksScriptNode{call.Args[0]},
 						},
@@ -902,10 +900,10 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		return BloksLiteralOf(btype), nil
 	case "bk.action.mins.GetByValOr":
 		return i.Evaluate(ctx, &BloksScriptNode{
-			BloksScriptNodeContent: &BloksScriptFuncall{
+			Content: &BloksScriptFuncall{
 				Function: "bk.action.bool.Or",
 				Args: []BloksScriptNode{{
-					BloksScriptNodeContent: &BloksScriptFuncall{
+					Content: &BloksScriptFuncall{
 						Function: "bk.action.map.Get",
 						Args: []BloksScriptNode{
 							call.Args[0],
@@ -1006,7 +1004,7 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		}
 		err = i.Bridge.StartTimer(name, time.Duration(interval)*time.Millisecond, func() error {
 			_, err := i.Evaluate(ctx, &BloksScriptNode{
-				BloksScriptNodeContent: &BloksScriptFuncall{
+				Content: &BloksScriptFuncall{
 					Function: "bk.action.core.Apply",
 					Args: []BloksScriptNode{{
 						BloksLiteralOf(cb),

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -657,6 +657,33 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 			return nil, err
 		}
 		return BloksLiteralOf(int64(len(arr))), nil
+	case "bk.action.array.Get":
+		mapping, err := i.Evaluate(ctx, &call.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		switch val := mapping.Value().(type) {
+		case map[string]*BloksScriptLiteral:
+			key, err := evalAs[string](ctx, i, &call.Args[1], "array.get")
+			if err != nil {
+				return nil, err
+			}
+			if val[key] == nil {
+				return nil, fmt.Errorf("array key %s not present in map", key)
+			}
+			return val[key], nil
+		case []*BloksScriptLiteral:
+			idx, err := evalAs[int64](ctx, i, &call.Args[1], "array.get")
+			if err != nil {
+				return nil, err
+			}
+			if idx < 0 || idx >= int64(len(val)) {
+				return nil, fmt.Errorf("array index %d out of bounds for length %d", idx, len(val))
+			}
+			return val[idx], nil
+		default:
+			return nil, fmt.Errorf("expected array or map in array.get, got %T", mapping.Value())
+		}
 	case "ig.action.IsDarkModeEnabled":
 		return BloksLiteralOf(false), nil
 	case "bk.action.mins.InByVal":

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -34,7 +34,7 @@ type InterpBridge struct {
 	HandleLoginResponse  func(ctx context.Context, data string) error
 	StartTimer           func(name string, interval time.Duration, callback func() error) error
 	OpenURL              func(url string) error
-	HandleVariableChange func(name string, value *BloksScriptLiteral) error
+	HandleVariableChange func(ctx context.Context, name string, value *BloksScriptLiteral) error
 }
 
 type Interpreter struct {
@@ -157,7 +157,7 @@ func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *
 		}
 	}
 	if br.HandleVariableChange == nil {
-		br.HandleVariableChange = func(name string, value *BloksScriptLiteral) error {
+		br.HandleVariableChange = func(ctx context.Context, name string, value *BloksScriptLiteral) error {
 			return nil
 		}
 	}
@@ -563,7 +563,7 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 			return nil, err
 		}
 		i.GlobalVars[BloksVariableID(varname)] = value
-		err = i.Bridge.HandleVariableChange(varname, value)
+		err = i.Bridge.HandleVariableChange(ctx, varname, value)
 		if err != nil {
 			return nil, err
 		}
@@ -973,20 +973,22 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		}
 		return BloksLiteralOf(btype), nil
 	case "bk.action.mins.GetByValOr":
-		return i.Evaluate(ctx, &BloksScriptNode{
+		lookup, err := i.Evaluate(ctx, &BloksScriptNode{
 			Content: &BloksScriptFuncall{
-				Function: "bk.action.bool.Or",
-				Args: []BloksScriptNode{{
-					Content: &BloksScriptFuncall{
-						Function: "bk.action.map.Get",
-						Args: []BloksScriptNode{
-							call.Args[0],
-							call.Args[1],
-						},
-					},
-				}, call.Args[2]},
+				Function: "bk.action.map.Get",
+				Args: []BloksScriptNode{
+					call.Args[0],
+					call.Args[1],
+				},
 			},
 		})
+		if err != nil {
+			return nil, err
+		}
+		if lookup.Value() == nil {
+			return i.Evaluate(ctx, &call.Args[2])
+		}
+		return lookup, nil
 	case "bk.action.fx.OpenSyncScreen", "bk.action.fx.PushSyncScreen":
 		name, err := evalTreeProp35(ctx, i, &call.Args[0], "pushscreen")
 		if err != nil {

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -120,9 +120,14 @@ func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *
 			return nil
 		}
 	}
-	if br.DoRPC == nil {
-		br.DoRPC = func(ctx context.Context, name string, params map[string]string, isPage bool, callback func(result *BloksScriptLiteral) error) error {
-			return fmt.Errorf("unhandled rpc %s (isPage %v)", name, isPage)
+	if br.DoPageRPC == nil {
+		br.DoPageRPC = func(ctx context.Context, name string, params map[string]string) (*BloksBundle, error) {
+			return nil, fmt.Errorf("unhandled page rpc %s", name)
+		}
+	}
+	if br.DoActionRPC == nil {
+		br.DoActionRPC = func(ctx context.Context, name string, params map[string]string) (*BloksScriptNode, error) {
+			return nil, fmt.Errorf("unhandled action rpc %s", name)
 		}
 	}
 	if br.DisplayNewScreen == nil {

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"regexp"
 	"strings"
 	"time"
@@ -48,19 +49,25 @@ type Interpreter struct {
 func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *Interpreter) (*Interpreter, error) {
 	p := b.Layout.Payload
 	scripts := map[BloksScriptID]*BloksLambda{}
+	payloads := map[BloksPayloadID]*BloksBundleRef{}
+	globals := map[BloksVariableID]*BloksScriptLiteral{}
+	locals := map[BloksVariableID]*BloksScriptLiteral{}
+	if old != nil {
+		maps.Copy(scripts, old.Scripts)
+		maps.Copy(payloads, old.Payloads)
+		maps.Copy(globals, old.GlobalVars)
+		maps.Copy(locals, old.LocalVars)
+	}
 	for id, script := range p.Scripts {
 		scripts[id] = &BloksLambda{
 			Body: &script.AST,
 		}
 	}
-	payloads := map[BloksPayloadID]*BloksBundleRef{}
 	for _, payload := range p.Embedded {
 		payloads[payload.ID] = &BloksBundleRef{
 			Bundle: &payload.Contents,
 		}
 	}
-	globals := map[BloksVariableID]*BloksScriptLiteral{}
-	locals := map[BloksVariableID]*BloksScriptLiteral{}
 	for _, item := range p.Variables {
 		// Deal with the dynamic variables later
 		if item.Info.InitialScript != nil {
@@ -69,14 +76,13 @@ func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *
 		id := BloksVariableID(item.ID)
 		switch item.Type {
 		case "gs":
-			if old != nil {
-				if oldval, ok := old.GlobalVars[id]; ok {
-					globals[id] = oldval
-					break
-				}
+			// Check if global var was already set
+			if globals[id] != nil {
+				break
 			}
 			globals[id] = BloksLiteralFromJavaScript(item.Info.Initial)
 		case "ls":
+			// Local vars do not carry over between screens
 			locals[id] = BloksLiteralFromJavaScript(item.Info.Initial)
 		default:
 			return nil, fmt.Errorf("unexpected var type %s", item.Type)
@@ -181,6 +187,23 @@ func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *
 		}
 	}
 	return &interp, nil
+}
+
+func (interp *Interpreter) MergeActionBundle(b *BloksBundle) {
+	p := b.Layout.Payload
+	for id, script := range p.Scripts {
+		interp.Scripts[id] = &BloksLambda{
+			Body: &script.AST,
+		}
+	}
+	for _, payload := range p.Embedded {
+		interp.Payloads[payload.ID] = &BloksBundleRef{
+			Bundle: &payload.Contents,
+		}
+	}
+	// We might want to handle variables here as well. Or combine this with
+	// the main method for constructing a new Interpreter instance based on
+	// an old one.
 }
 
 type BloksLambda struct {

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -169,6 +169,9 @@ func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *
 		if item.Info.InitialScript == nil {
 			continue
 		}
+		// Technically we shouldn't do this evaluation until after we
+		// know if the value will be used or not, but as of yet I have
+		// not seen a case where it matters.
 		value, err := interp.Evaluate(ctx, &item.Info.InitialScript.AST)
 		if err != nil {
 			return nil, fmt.Errorf("var %s: %w", item.ID, err)
@@ -176,14 +179,14 @@ func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *
 		id := BloksVariableID(item.ID)
 		switch item.Type {
 		case "gs":
-			if old != nil {
-				if oldval, ok := old.GlobalVars[id]; ok {
-					globals[id] = oldval
-					break
-				}
+			if globals[id] != nil {
+				break
 			}
 			globals[id] = value
 		case "ls":
+			if locals[id] != nil && !clearLocals {
+				break
+			}
 			locals[id] = value
 		default:
 			return nil, fmt.Errorf("unexpected var type %s", item.Type)

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -27,7 +27,8 @@ type InterpBridge struct {
 	IsAppInstalled       func(url string, pkgnames ...string) bool
 	HasAppPermissions    func(permissions ...string) bool
 	GetSecureNonces      func() []string
-	DoRPC                func(ctx context.Context, name string, params map[string]string, isPage bool, callback func(result *BloksScriptLiteral) error) error
+	DoPageRPC            func(ctx context.Context, name string, params map[string]string) (*BloksBundle, error)
+	DoActionRPC          func(ctx context.Context, name string, params map[string]string) (*BloksScriptNode, error)
 	DisplayNewScreen     func(context.Context, string, *BloksBundle) error
 	HandleLoginResponse  func(ctx context.Context, data string) error
 	StartTimer           func(name string, interval time.Duration, callback func() error) error
@@ -744,18 +745,20 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		if err != nil {
 			return nil, err
 		}
-		err = i.Bridge.DoRPC(ctx, name, flatParams, false, func(result *BloksScriptLiteral) error {
-			_, err := i.Evaluate(ctx, &BloksScriptNode{
-				BloksScriptNodeContent: &BloksScriptFuncall{
-					Function: "bk.action.core.Apply",
-					Args: []BloksScriptNode{{
-						BloksLiteralOf(callback),
-					}, {
-						result,
-					}},
-				},
-			})
-			return err
+		action, err := i.Bridge.DoActionRPC(ctx, name, flatParams)
+		if err != nil {
+			return nil, err
+		}
+		// Evaluate the action and also pass it to the callback
+		_, err = i.Evaluate(ctx, &BloksScriptNode{
+			BloksScriptNodeContent: &BloksScriptFuncall{
+				Function: "bk.action.core.Apply",
+				Args: []BloksScriptNode{{
+					BloksLiteralOf(callback),
+				}, {
+					action,
+				}},
+			},
 		})
 		if err != nil {
 			return nil, err
@@ -948,7 +951,11 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 			}
 			flatParams[key] = str
 		}
-		err = i.Bridge.DoRPC(ctx, name, flatParams, true, nil)
+		page, err := i.Bridge.DoPageRPC(ctx, name, flatParams)
+		if err != nil {
+			return nil, err
+		}
+		err = i.Bridge.DisplayNewScreen(ctx, name, page)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -195,21 +195,17 @@ func NewInterpreter(ctx context.Context, b *BloksBundle, br *InterpBridge, old *
 	return &interp, nil
 }
 
-func (interp *Interpreter) MergeActionBundle(b *BloksBundle) {
-	p := b.Layout.Payload
-	for id, script := range p.Scripts {
-		interp.Scripts[id] = &BloksLambda{
-			Body: &script.AST,
-		}
+func (interp *Interpreter) MergeActionBundle(ctx context.Context, b *BloksBundle) error {
+	// Kind of a hack, maybe do this better
+	newInterp, err := NewInterpreter(ctx, b, &interp.Bridge, interp, false)
+	if err != nil {
+		return err
 	}
-	for _, payload := range p.Embedded {
-		interp.Payloads[payload.ID] = &BloksBundleRef{
-			Bundle: &payload.Contents,
-		}
-	}
-	// We might want to handle variables here as well. Or combine this with
-	// the main method for constructing a new Interpreter instance based on
-	// an old one.
+	interp.Scripts = newInterp.Scripts
+	interp.Payloads = newInterp.Payloads
+	interp.LocalVars = newInterp.LocalVars
+	interp.GlobalVars = newInterp.GlobalVars
+	return nil
 }
 
 type BloksLambda struct {

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -215,6 +215,20 @@ func evalAs[T any](ctx context.Context, i *Interpreter, form *BloksScriptNode, w
 	return cast, nil
 }
 
+func evalFloat(ctx context.Context, i *Interpreter, form *BloksScriptNode, where string) (float64, error) {
+	val, err := i.Evaluate(ctx, form)
+	if err != nil {
+		return 0, err
+	}
+	if cast, ok := val.Value().(float64); ok {
+		return cast, nil
+	}
+	if cast, ok := val.Value().(int64); ok {
+		return float64(cast), nil
+	}
+	return 0, fmt.Errorf("expected int64 or float64 in %s, got %T", where, val.Value())
+}
+
 func evalTreeProp35(ctx context.Context, i *Interpreter, form *BloksScriptNode, where string) (string, error) {
 	make, ok := form.Content.(*BloksScriptFuncall)
 	if !ok {
@@ -485,6 +499,16 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		return BloksLiteralOf(first > second), nil
 	case "bk.action.f32.Const":
 		return i.Evaluate(ctx, &call.Args[0])
+	case "bk.action.f32.Add":
+		first, err := evalFloat(ctx, i, &call.Args[0], "add lhs")
+		if err != nil {
+			return nil, err
+		}
+		second, err := evalFloat(ctx, i, &call.Args[1], "add rhs")
+		if err != nil {
+			return nil, err
+		}
+		return BloksLiteralOf(first + second), nil
 	case "bk.action.bloks.GetScript":
 		name, err := evalAs[string](ctx, i, &call.Args[0], "getscript")
 		if err != nil {

--- a/pkg/messagix/bloks/script.go
+++ b/pkg/messagix/bloks/script.go
@@ -9,7 +9,10 @@ import (
 )
 
 type BloksScriptNode struct {
-	BloksScriptNodeContent
+	// Make this an explicit field because otherwise it becomes
+	// legal to put a BloksScriptNode as a BloksScriptNodeContent
+	// because the type checker doesn't care about your feelings
+	Content BloksScriptNodeContent
 }
 
 var ErrParseEndOfFuncall = errors.New("end of funcall")
@@ -21,13 +24,13 @@ func (node *BloksScriptNode) ParseAny(code string, start int) (int, error) {
 			continue
 		case '(':
 			funcall := BloksScriptFuncall{}
-			node.BloksScriptNodeContent = &funcall
+			node.Content = &funcall
 			return funcall.Parse(code, idx)
 		case ')':
 			return idx, ErrParseEndOfFuncall
 		default:
 			var literal BloksScriptLiteral
-			node.BloksScriptNodeContent = &literal
+			node.Content = &literal
 			return literal.Parse(code, idx)
 		}
 	}
@@ -113,7 +116,7 @@ func (call *BloksScriptFuncall) Unminify(m *Unminifier) {
 		call.Function = real
 	}
 	for _, arg := range call.Args {
-		arg.Unminify(m)
+		arg.Content.Unminify(m)
 	}
 }
 
@@ -126,7 +129,7 @@ func (call *BloksScriptFuncall) Print(w io.Writer, indent string) error {
 		if idx > 0 {
 			fmt.Fprintf(w, "\n")
 		}
-		arg.Print(w, indent+"  ")
+		arg.Content.Print(w, indent+"  ")
 	}
 	fmt.Fprintf(w, ")")
 	return nil
@@ -155,12 +158,12 @@ func (call *BloksScriptFuncall) Redact() {
 	}
 	for idx, arg := range call.Args {
 		if nonsensitive[idx] {
-			switch arg.BloksScriptNodeContent.(type) {
+			switch arg.Content.(type) {
 			case *BloksScriptLiteral:
 				continue
 			}
 		}
-		arg.Redact()
+		arg.Content.Redact()
 	}
 }
 

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -468,11 +468,14 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 			}
 			// Action payload doesn't include a new page, but it might include some
 			// extra payloads or scripts, we need to merge those in.
-			interp, err := NewInterpreter(ctx, bundle, b.Bridge, b.CurrentPage.GetInterpreter(), false)
+			//
+			// NB: Terrible bug happens if you re-assign b.CurrentPage.Interpreter here,
+			// because the calling code still has a reference to the old interpreter and
+			// any variable updates in the callback will be lost.
+			err = b.CurrentPage.Interpreter.MergeActionBundle(ctx, bundle)
 			if err != nil {
 				return nil, fmt.Errorf("merging interpreter with new action")
 			}
-			b.CurrentPage.Interpreter = interp
 			return action, nil
 		},
 		DisplayNewScreen: func(ctx context.Context, name string, page *BloksBundle) error {

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -468,7 +468,7 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 			}
 			// Action payload doesn't include a new page, but it might include some
 			// extra payloads or scripts, we need to merge those in.
-			interp, err := NewInterpreter(ctx, bundle, b.Bridge, b.CurrentPage.GetInterpreter())
+			interp, err := NewInterpreter(ctx, bundle, b.Bridge, b.CurrentPage.GetInterpreter(), false)
 			if err != nil {
 				return nil, fmt.Errorf("merging interpreter with new action")
 			}
@@ -521,7 +521,7 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 				return fmt.Errorf("can't handle new screen %s in state %s", name, b.State)
 			}
 
-			err := page.SetupInterpreter(ctx, b.Bridge, b.CurrentPage.GetInterpreter())
+			err := page.SetupInterpreter(ctx, b.Bridge, b.CurrentPage.GetInterpreter(), true)
 			if err != nil {
 				return err
 			}
@@ -677,7 +677,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 		// not a page.
 		b.CurrentPage = action
 
-		err = action.SetupInterpreter(ctx, b.Bridge, nil)
+		err = action.SetupInterpreter(ctx, b.Bridge, nil, true)
 		if err != nil {
 			return nil, fmt.Errorf("setup %s interpreter: %w", b.State, err)
 		}

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -738,6 +738,17 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 					thing = "email address"
 				}
 				b.LastError = fmt.Sprintf("That %s is not connected to a Messenger account", thing)
+			} else if strings.Contains(err.Error(), "com.bloks.www.caa.assistive_login_confirmation") {
+				// Facebook tries to send us to this screen when they think we are
+				// demonstrating substantial incompetence at entering an email
+				// address, like not putting a domain after the at-sign. It really
+				// just means the email address isn't valid though so let's report
+				// it like that.
+				//
+				// Technically we don't know that's the ONLY case where this screen
+				// comes up, but it's the only one sighted thus far. Update this if
+				// something new is discovered.
+				b.LastError = "Invalid email address"
 			} else {
 				return nil, fmt.Errorf("tapping login button: %w", err)
 			}

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -274,43 +274,24 @@ type BrowserState string
 // MFA = Multi-Factor Authentication
 // AP = Authentication Platform
 const (
-	StateUnknown                    BrowserState = ""
-	StateTestCaptcha                BrowserState = "test-captcha"
-	StateInitial                    BrowserState = "initial"
-	StateRedirectToLoginAction      BrowserState = "redirect-to-login-action"
-	StateEmailPasswordPage          BrowserState = "enter-email-and-password-page"
-	StateEnteredEmailPasswordAction BrowserState = "entered-email-and-password-action"
-	StateEmailCodePage              BrowserState = "enter-code-from-email-page"
-	StateEnteredEmailCodeAction     BrowserState = "entered-code-from-email-action"
-	StateEnteredEmailCodeAPAction   BrowserState = "entered-code-from-email-ap-action"
-	StateRedirectToMFALandingAction BrowserState = "redirect-to-mfa-landing-action"
-	StateCaptchaPage                BrowserState = "captcha-page"
-	StateEnteredCaptchaAction       BrowserState = "entered-captcha-action"
-	StateMFALandingAPAction         BrowserState = "mfa-landing-ap-action"
-	StateMFALandingPage             BrowserState = "mfa-landing-page"
-	StatePossibleMandatoryAFADPAge  BrowserState = "possibly-mandatory-afad-page"
-	StateChooseMFAAPAction          BrowserState = "choose-mfa-ap-action"
-	StateChooseMFAPage              BrowserState = "choose-mfa-type-page"
-	StateChosenMFAAPAction          BrowserState = "chosen-mfa-type-ap-action"
-	StateChosenMFAAction            BrowserState = "chosen-mfa-type-action"
-	StateAFADPage                   BrowserState = "afad-page"
-	StateAFADAction                 BrowserState = "afad-action"
-	StateAFADWait                   BrowserState = "afad-waiting"
-	StateAFADCompleteAction         BrowserState = "afad-complete-action"
-	StateTOTPPage                   BrowserState = "totp-page"
-	StateEnteredTOTPAction          BrowserState = "entered-totp-action"
-	StateOAuthPage                  BrowserState = "oauth-page"
-	StateSMSPage                    BrowserState = "sms-page"
-	StateSMSPageAfterSend           BrowserState = "sms-page-after-send"
-	StateSendSMSAction              BrowserState = "send-sms-action"
-	StateEnteredSMSAction           BrowserState = "entered-sms-action"
-	StateBackupCodePage             BrowserState = "backup-code-page"
-	StateEnteredBackupCodeAction    BrowserState = "entered-backup-code-action"
-	StateWhatsAppPage               BrowserState = "whatsapp-page"
-	StateWhatsAppPageAfterSend      BrowserState = "whatsapp-page-after-send"
-	StateSendWhatsAppAction         BrowserState = "send-whatsapp-action"
-	StateEnteredWhatsAppAction      BrowserState = "entered-whatsapp-action"
-	StateSuccess                    BrowserState = "success"
+	StateUnknown               BrowserState = ""
+	StateTestCaptcha           BrowserState = "test-captcha"
+	StateInitial               BrowserState = "initial"
+	StateEmailPasswordPage     BrowserState = "enter-email-and-password-page"
+	StateEmailCodePage         BrowserState = "enter-code-from-email-page"
+	StateCaptchaPage           BrowserState = "captcha-page"
+	StateMFALandingPage        BrowserState = "mfa-landing-page"
+	StateChooseMFAPage         BrowserState = "choose-mfa-type-page"
+	StateAFADPage              BrowserState = "afad-page"
+	StateAFADPageWaiting       BrowserState = "afad-waiting"
+	StateTOTPPage              BrowserState = "totp-page"
+	StateOAuthPage             BrowserState = "oauth-page"
+	StateSMSPage               BrowserState = "sms-page"
+	StateSMSPageAfterSend      BrowserState = "sms-page-after-send"
+	StateBackupCodePage        BrowserState = "backup-code-page"
+	StateWhatsAppPage          BrowserState = "whatsapp-page"
+	StateWhatsAppPageAfterSend BrowserState = "whatsapp-page-after-send"
+	StateSuccess               BrowserState = "success"
 )
 
 type BrowserConfig struct {
@@ -319,25 +300,108 @@ type BrowserConfig struct {
 }
 
 type Browser struct {
-	State         BrowserState
-	CurrentPage   *BloksBundle
-	CurrentAction *BloksBundle
+	State       BrowserState
+	CurrentPage *BloksBundle
 
 	Config *BrowserConfig
 	Bridge *InterpBridge
 
-	CaptchaCallback    func(*BloksScriptLiteral) error
-	NumCaptchaAttempts int
-
 	AFADNotification string
 	AFADInterval     time.Duration
-	AFADCallback     func(*BloksScriptLiteral) error
-	AFADDisplayed    bool
+	AFADCallback     func() error
 	LoginData        string
 	DisplayedURL     string
 
 	LastError string
 }
+
+// You will want an explanation of how to maintain this code.
+//
+// The problem being solved is tricky because Facebook wants to shake their frontend around like a
+// dog with a stick, and you never really know which way things will get yanked. State changes
+// happen in all kinds of callbacks. But at the same time we kind of need to keep track of where we
+// are at least a bit, so we know what page we're on and whether there was an error we need to
+// report to the user. Despite not being able to write down the whole flow graph explicitly.
+//
+// The current implementation of the page state graph works as follows.
+//
+// There is a single b.State variable that keeps track of what page we're on. This is associated
+// with a single Bloks bundle stored in b.CurrentPage. Only one page can be displayed/active at a
+// time. Now note that there are also Bloks bundles that represent actions. But these aren't
+// incorporated into the state graph, unlike in previous versions of this code. Instead, when we get
+// an action bundle, we execute it immediately, and just catch up later to see if it did what we
+// were hoping it would.
+//
+// The state starts off in StateInitial, which kicks things off by making a Bloks request manually
+// and executing the action that it gets back. When an action is executed, it can trigger further
+// action RPC calls, which can execute further actions. Or it can trigger page RPC calls, which lead
+// to the interpreter invoking DisplayNewScreen, which updates the page state.
+//
+// Now, depending on the page state, we have a big switch statement that tells us what actions to
+// undertake. This maps reasonably to the human interpretation of "which page am I looking at, and
+// therefore what buttons should I try to tap". We expect that executing the logic for a given page
+// will do some sequence of actions that navigates us to another page, and if it doesn't, we crash.
+// The tricky part comes in when we want to incorporate user input and recoverable errors into that
+// flow.
+//
+// User input: Our implementation here is driven in part by how bridgev2 handles user input. Which
+// is that you return a list of input fields, then get called back later with the values for those
+// input fields, and must then return another list of input fields, and so on until eventually you
+// return success. To provide that interface on top of our big switch statement, we put the switch
+// statement in a loop, and give each switch case the capability to return user input fields. Then
+// the loop keeps running the switch statement to transition through pages until reaching one where
+// the implementation says "this page needs some inputs to complete". Bridgev2 calls us back later
+// with the values for those inputs, and the same switch case sees that it has now been passed
+// values, so it skips over returning the user input list, and instead uses those values to complete
+// the page logic.
+//
+// Recoverable errors: This is handled by a single b.LastError variable, which is intended
+// exclusively for recoverable errors that occur within a single page (i.e., an error that occurs by
+// redirecting to a separate error page would not be handled by this mechanism). We have at least
+// two different ways we can get a recoverable error, which Facebook chooses between based on
+// planetary alignment and the phase of the moon.
+//
+// One is that executing the page interactions can trigger a Bloks error popup, which the
+// interpreter translates into returning a Golang error object. In cases where this might happen due
+// to bad user input, we check the error return value, see if it's an error message from Facebook
+// that we understand, and if so, assign it to b.LastError. (Otherwise we just return it as fatal.)
+//
+// The second case is that executing the page interactions doesn't throw an error, but does update a
+// page variable, which is intended to display the error message inline. Rather than try to parse
+// out those inline error messages from the actual page contents, which is tricky given Facebook's
+// disgusting lack of proper CSS selector or other navigability/accessibility features, we just use
+// the interpreter to hook onto those variables, and update b.LastError when one of them gets set.
+//
+// In summary, we execute the page logic, maybe catch certain errors, and at the end of it, either
+// we are on a new page (in which case b.LastError is reset), or we are still on the same page and
+// b.LastError is set to something (in which case we loop back, display the error to the user, and
+// ask for input again), or we are still on the same page and there is no b.LastError (in which case
+// there has been a logic error and we crash).
+//
+// To make the above happen as described, we follow this pattern for all switch cases that take user
+// input:
+//
+// ```
+// case StateAskingForXYZPage:
+//   xyz := userInput["xyz"]
+//   if xyz == "" {
+//     step = &bridgev2.LoginStep{ ... }
+//     break
+//   }
+//
+//   delete(userInput, "xyz")
+//   b.LastError = "Some generic message about how XYZ was rejected"
+//
+//   ... try to submit xyz, maybe overwrite b.LastError ...
+// ```
+//
+// If the submission logic works, and we end up on a new page, b.LastError is thrown away. If it
+// doesn't work, we have a placeholder error message that can be shown to the user next time.
+// (Include it into the instructions in the returned LoginStep if it's set.) If our variable watches
+// or error checking work properly, we will get a more specific b.LastError that can be used
+// instead. And finally, note that deleting the field from userInput ensures that if we end up in an
+// error state, then we'll re-prompt the user for input, rather than reusing what they gave last
+// time.
 
 func NewBrowser(cfg *BrowserConfig) *Browser {
 	b := Browser{
@@ -364,157 +428,89 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 		// cannot be generated on the client side so this fact is purely informational.
 		MachineID:       "",
 		EncryptPassword: cfg.EncryptPassword,
-		DoRPC: func(ctx context.Context, name string, params map[string]string, isPage bool, callback func(result *BloksScriptLiteral) error) error {
+		DoPageRPC: func(ctx context.Context, name string, params map[string]string) (*BloksBundle, error) {
 			log := zerolog.Ctx(ctx)
-			log.Debug().Str("state", string(b.State)).Str("rpc", name).Msg("Invoking RPC from Bloks")
-			mayQueryError := false
-			transitions := map[BrowserState]BrowserState{}
-			switch name {
-			case "com.bloks.www.bloks.caa.login.async.send_login_request":
-				transitions[StateEmailPasswordPage] = StateEnteredEmailPasswordAction
-			case "com.bloks.www.two_step_verification.entrypoint":
-				transitions[StateEnteredEmailPasswordAction] = StateMFALandingPage
-				transitions[StateEnteredEmailCodeAction] = StateMFALandingPage
-				transitions[StateEnteredCaptchaAction] = StateMFALandingPage
-			case "com.bloks.www.two_step_verification.async.entrypoint":
-				transitions[StateEnteredEmailPasswordAction] = StateRedirectToMFALandingAction
-			case "com.bloks.www.two_step_verification.enter_text_captcha_code":
-				transitions[StateRedirectToMFALandingAction] = StateCaptchaPage
-			case "com.bloks.www.two_step_verification.login.async.text_captcha":
-				transitions[StateCaptchaPage] = StateEnteredCaptchaAction
-			case "com.bloks.www.ap.two_step_verification.entrypoint_async":
-				transitions[StateEnteredEmailPasswordAction] = StateMFALandingAPAction
-				transitions[StateEnteredCaptchaAction] = StateMFALandingAPAction
-				// This RPC is sometimes rejected with a generic "server error
-				// field_exception" response when transitioning from the captcha
-				// page to the MFA landing page. The error can be reproduced on the
-				// official Messenger iOS app so it is not a bridge issue. Entering
-				// the wrong captcha produces a different, non-error response - so
-				// we know there is nothing the user could do to cause this, it is
-				// purely Meta's fault.
-				mayQueryError = true
-			case "com.bloks.www.ap.two_step_verification.approve_from_another_device":
-				transitions[StateMFALandingAPAction] = StatePossibleMandatoryAFADPAge
-				transitions[StateChosenMFAAPAction] = StateAFADPage
-			case "com.bloks.www.ap.two_step_verification.approve_from_another_device_async":
-				transitions[StatePossibleMandatoryAFADPAge] = StateChooseMFAAPAction
-				transitions[StateMFALandingPage] = StateChooseMFAAPAction
-			case "com.bloks.www.ap.two_step_verification.challenge_picker":
-				transitions[StateChooseMFAAPAction] = StateChooseMFAPage
-			case "com.bloks.www.bloks.ap.two_step_verification.challenge_picker.async":
-				transitions[StateChooseMFAPage] = StateChosenMFAAPAction
-			case "com.bloks.www.two_step_verification.verify_code.async":
-				transitions[StateTOTPPage] = StateEnteredTOTPAction
-				transitions[StateSMSPageAfterSend] = StateEnteredSMSAction
-				transitions[StateWhatsAppPageAfterSend] = StateEnteredWhatsAppAction
-				transitions[StateBackupCodePage] = StateEnteredBackupCodeAction
-			case "com.bloks.www.two_step_verification.method_picker":
-				transitions[StateMFALandingPage] = StateChooseMFAPage
-			case "com.bloks.www.two_step_verification.method_picker.navigation.async":
-				transitions[StateChooseMFAPage] = StateChosenMFAAction
-			case "com.bloks.www.ap.two_step_verification.code_entry":
-				transitions[StateChosenMFAAPAction] = StateEmailCodePage
-			case "com.bloks.www.caa.ar.submit_code.async":
-				transitions[StateEmailCodePage] = StateEnteredEmailCodeAction
-			case "com.bloks.www.ap.two_step_verification.code_entry_async":
-				transitions[StateEmailCodePage] = StateEnteredEmailCodeAPAction
-			case "com.bloks.www.two_factor_login.enter_totp_code":
-				transitions[StateChosenMFAAction] = StateTOTPPage
-			case "com.bloks.www.two_step_verification.approve_from_another_device":
-				transitions[StateChosenMFAAction] = StateAFADPage
-			case "com.bloks.www.two_step_verification.afad_state.async":
-				transitions[StateAFADPage] = StateAFADAction
-			case "com.bloks.www.two_step_verification.afad_complete.async":
-				transitions[StateAFADAction] = StateAFADCompleteAction
-			case "com.bloks.www.ap.two_step_verification.login_with_third_party":
-				transitions[StateChosenMFAAPAction] = StateOAuthPage
-			case "com.bloks.www.two_step_verification.enter_sms_code":
-				transitions[StateChosenMFAAction] = StateSMSPage
-			case "com.bloks.www.two_step_verification.send_code.async":
-				transitions[StateSMSPage] = StateSendSMSAction
-				transitions[StateWhatsAppPage] = StateSendWhatsAppAction
-			case "com.bloks.www.two_factor_login.enter_backup_code":
-				transitions[StateChosenMFAAction] = StateBackupCodePage
-			case "com.bloks.www.two_step_verification.enter_whatsapp_code":
-				transitions[StateChosenMFAAction] = StateWhatsAppPage
-			case "com.bloks.www.bloks.caa.reg.youthregulation.deletepregent.async":
-				// Ignore this for now as it doesn't seem required.
-				//
-				// If it becomes important, implement a better framework for
-				// allowing arbitrary actions to be executed without leaving the
-				// current page state.
-				return nil
-			default:
-				return fmt.Errorf("unexpected rpc %s isPage=%v", name, isPage)
-			}
-			if transitions[b.State] == StateUnknown {
-				return fmt.Errorf("can't handle rpc %s in state %s", name, b.State)
-			}
-
+			log.Debug().Str("state", string(b.State)).Str("rpc", name).Str("rpc_type", "page").Msg("Invoking RPC from Bloks")
 			var paramsInner BloksParamsInner
 			err := json.Unmarshal([]byte(params["params"]), &paramsInner)
 			if err != nil {
-				return fmt.Errorf("parsing %s params: %w", name, err)
+				return nil, fmt.Errorf("parsing %s params: %w", name, err)
 			}
-
-			var doc *BloksDoc
-			if isPage {
-				doc = &BloksAppDoc
-			} else {
-				doc = &BloksActionDoc
-			}
-
-			pageOrAction, err := cfg.MakeBloksRequest(ctx, doc, NewBloksRequest(name, paramsInner))
+			bundle, err := cfg.MakeBloksRequest(ctx, &BloksAppDoc, NewBloksRequest(name, paramsInner))
 			if err != nil {
-				if mayQueryError && strings.Contains(err.Error(), "Query Error") {
-					return ErrLoginUninformative
+				return nil, fmt.Errorf("rpc %s: %w", name, err)
+			}
+			return bundle, nil
+		},
+		DoActionRPC: func(ctx context.Context, name string, params map[string]string) (*BloksScriptNode, error) {
+			log := zerolog.Ctx(ctx)
+			log.Debug().Str("state", string(b.State)).Str("rpc", name).Str("rpc_type", "action").Msg("Invoking RPC from Bloks")
+			var paramsInner BloksParamsInner
+			err := json.Unmarshal([]byte(params["params"]), &paramsInner)
+			if err != nil {
+				return nil, fmt.Errorf("parsing %s params: %w", name, err)
+			}
+			bundle, err := cfg.MakeBloksRequest(ctx, &BloksActionDoc, NewBloksRequest(name, paramsInner))
+			if err != nil {
+				return nil, fmt.Errorf("rpc %s: %w", name, err)
+			}
+			action := bundle.Action()
+			if action == nil {
+				// This is a super weird action that appears to be handled by the Bloks runtime in
+				// an unusual way. It is basically an action, but formatted as a page with a
+				// component inside it that has the action code, but then the page itself is tagged
+				// as an action.
+				script := bundle.FindDescendant(FilterByComponent("action")).GetScript("on_load")
+				if script == nil {
+					return nil, fmt.Errorf("AP action from rpc %s did not contain script", name)
 				}
-				return fmt.Errorf("rpc %s: %w", name, err)
+				action = &script.AST
 			}
-
-			err = pageOrAction.SetupInterpreter(ctx, b.Bridge, b.CurrentPage.GetInterpreter())
-			if err != nil {
-				return err
-			}
-
-			if isPage {
-				b.CurrentPage = pageOrAction
-			} else {
-				b.CurrentAction = pageOrAction
-			}
-
-			b.State = transitions[b.State]
-
-			switch b.State {
-			case StateAFADAction:
-				b.AFADCallback = callback
-			case StateEnteredCaptchaAction:
-				b.CaptchaCallback = callback
-			case StateSendSMSAction:
-				// For now we won't actually evaluate the action because it is a
-				// little awkward to do so, and it does not seem required. This
-				// should be fixed at some point.
-				b.State = StateSMSPageAfterSend
-			case StateSendWhatsAppAction:
-				// Same deal here.
-				b.State = StateWhatsAppPageAfterSend
-			}
-
-			return nil
+			return action, nil
 		},
 		DisplayNewScreen: func(ctx context.Context, name string, page *BloksBundle) error {
 			log := zerolog.Ctx(ctx)
 			log.Debug().Str("state", string(b.State)).Str("screen", name).Msg("Displaying new screen from Bloks")
-			transitions := map[BrowserState]BrowserState{}
+			newState := StateUnknown
 			switch name {
 			case "com.bloks.www.caa.login.login_homepage":
-				transitions[StateRedirectToLoginAction] = StateEmailPasswordPage
-			case "com.bloks.www.caa.ar.code_entry":
-				transitions[StateEnteredEmailPasswordAction] = StateEmailCodePage
+				newState = StateEmailPasswordPage
+			case "com.bloks.www.caa.ar.code_entry",
+				"com.bloks.www.ap.two_step_verification.code_entry":
+				newState = StateEmailCodePage
+			case "com.bloks.www.two_step_verification.entrypoint":
+				newState = StateMFALandingPage
+			case "com.bloks.www.two_step_verification.enter_text_captcha_code":
+				newState = StateCaptchaPage
+			case "com.bloks.www.ap.two_step_verification.approve_from_another_device",
+				"com.bloks.www.two_step_verification.approve_from_another_device":
+				// Meta tends to send you here by default and we need to treat it as
+				// a landing page that we then navigate to the MFA method picker
+				// from. But in case we already went to the method picker and picked
+				// AFAD, then we will end up back here and we want to actually do
+				// AFAD, not redirect back to the picker again.
+				if b.State == StateChooseMFAPage {
+					newState = StateAFADPage
+				} else {
+					newState = StateMFALandingPage
+				}
+			case "com.bloks.www.ap.two_step_verification.challenge_picker",
+				"com.bloks.www.two_step_verification.method_picker":
+				newState = StateChooseMFAPage
+			case "com.bloks.www.two_factor_login.enter_totp_code":
+				newState = StateTOTPPage
+			case "com.bloks.www.ap.two_step_verification.login_with_third_party":
+				newState = StateOAuthPage
+			case "com.bloks.www.two_step_verification.enter_sms_code":
+				newState = StateSMSPage
+			case "com.bloks.www.two_factor_login.enter_backup_code":
+				newState = StateBackupCodePage
+			case "com.bloks.www.two_step_verification.enter_whatsapp_code":
+				newState = StateWhatsAppPage
 			default:
 				return fmt.Errorf("unexpected new screen %s", name)
 			}
-			if transitions[b.State] == StateUnknown {
+			if newState == StateUnknown {
 				return fmt.Errorf("can't handle new screen %s in state %s", name, b.State)
 			}
 
@@ -524,37 +520,21 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 			}
 
 			b.CurrentPage = page
-			b.State = transitions[b.State]
+			b.State = newState
 			return nil
 		},
 		HandleLoginResponse: func(ctx context.Context, data string) error {
 			log := zerolog.Ctx(ctx)
 			log.Debug().Str("state", string(b.State)).Msg("Handling login response from Bloks")
-			transitions := map[BrowserState]BrowserState{}
-			transitions[StateEnteredEmailPasswordAction] = StateSuccess
-			transitions[StateEnteredCaptchaAction] = StateSuccess
-			transitions[StateEnteredTOTPAction] = StateSuccess
-			transitions[StateEnteredSMSAction] = StateSuccess
-			transitions[StateEnteredWhatsAppAction] = StateSuccess
-			transitions[StateEnteredBackupCodeAction] = StateSuccess
-			transitions[StateAFADCompleteAction] = StateSuccess
-			transitions[StateEnteredEmailCodeAction] = StateSuccess
-			transitions[StateEnteredEmailCodeAPAction] = StateSuccess
-			if transitions[b.State] == StateUnknown {
-				return fmt.Errorf("can't handle login response in state %s", b.State)
-			}
-
 			b.LoginData = data
-			b.State = transitions[b.State]
+			b.State = StateSuccess
 			return nil
 		},
 		StartTimer: func(name string, interval time.Duration, callback func() error) error {
 			switch name {
 			case "approve_from_another_device_polling_timer":
-				// The callback just re-runs the same on_appear logic, so for now
-				// we'll just re-load the page instead of actually triggering the
-				// callback logic in a loop.
 				b.AFADInterval = interval
+				b.AFADCallback = callback
 			default:
 				return fmt.Errorf("unexpected timer %s", name)
 			}
@@ -568,7 +548,7 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 			switch name {
 			case "BLOKS_TWO_STEP_VERIFICATION_ENTER_CODE:error_message":
 				switch b.State {
-				case StateEnteredTOTPAction, StateEnteredSMSAction, StateEnteredWhatsAppAction, StateEnteredBackupCodeAction:
+				case StateTOTPPage, StateSMSPage, StateWhatsAppPage, StateBackupCodePage:
 				default:
 					return nil
 				}
@@ -578,7 +558,7 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 				}
 				b.LastError = msg
 			case "BLOKS_AUTH_PLATFORM_ENTER_CODE:error_message":
-				if b.State != StateEnteredEmailCodeAPAction {
+				if b.State != StateEmailCodePage {
 					break
 				}
 				msg, ok := value.Value().(string)
@@ -685,178 +665,23 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			return nil, fmt.Errorf("rpc %s: %w", rpc, err)
 		}
 
-		err = action.SetupInterpreter(ctx, b.Bridge, b.CurrentPage.GetInterpreter())
+		// Arguably this is a bit wrong? We don't save this interpreter anywhere, and end up
+		// not having a CurrentPage interpreter in the initial DisplayNewScreen call, so it
+		// gets constructed from scratch. But this seems like it's working fine for now.
+		err = action.SetupInterpreter(ctx, b.Bridge, nil)
 		if err != nil {
 			return nil, fmt.Errorf("setup %s interpreter: %w", b.State, err)
 		}
 
-		b.CurrentAction = action
-		b.State = StateRedirectToLoginAction
-
-	case StateEnteredCaptchaAction:
-		b.NumCaptchaAttempts += 1
-
-		result, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
+		_, err = action.Interpreter.Evaluate(ctx, action.Action())
 		if err != nil {
-			return nil, fmt.Errorf("execute %s: %w", b.State, err)
-		}
-
-		err = b.CaptchaCallback(result)
-		if err != nil {
-			return nil, fmt.Errorf("execute captcha callback: %w", err)
-		}
-
-		if b.State == StateEnteredCaptchaAction {
-			b.State = StateCaptchaPage
-			delete(userInput, "captcha_code")
-		}
-
-	case StateMFALandingAPAction, StateChooseMFAAPAction, StateChosenMFAAPAction, StateEnteredEmailCodeAPAction:
-		action := b.CurrentAction.Action()
-		if action == nil {
-			// This is a super weird action that appears to be handled by the Bloks runtime in
-			// an unusual way. It is basically an action, but formatted as a page with a
-			// component inside it that has the action code, but then the page itself is tagged
-			// as an action.
-			script := b.CurrentAction.FindDescendant(FilterByComponent("action")).GetScript("on_load")
-			if script == nil {
-				return nil, fmt.Errorf("AP action %q did not contain script", b.State)
-			}
-			action = &script.AST
-		}
-
-		_, err := b.CurrentAction.Interpreter.Evaluate(ctx, action)
-		if err != nil {
-			return nil, fmt.Errorf("execute %s: %w", b.State, err)
-		}
-
-		if b.State == StateEnteredEmailCodeAPAction {
-			if b.LastError != "" {
-				delete(userInput, "email_code")
-				b.State = StateEmailCodePage
-			}
-		}
-
-	case StateAFADAction:
-		result, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
-		if err != nil {
-			return nil, fmt.Errorf("execute %s: %w", b.State, err)
-		}
-
-		err = b.AFADCallback(result)
-		if err != nil {
-			return nil, fmt.Errorf("execute AFAD callback: %w", err)
-		}
-
-		if b.State != StateAFADAction {
-			break
-		}
-
-		if b.AFADInterval <= 0 {
-			return nil, fmt.Errorf("no AFAD timer scheduled")
-		}
-
-		b.State = StateAFADWait
-
-		// Only display the login step once, keep polling in background
-		if !b.AFADDisplayed {
-			step = &bridgev2.LoginStep{
-				Type:         bridgev2.LoginStepTypeDisplayAndWait,
-				StepID:       "fi.mau.meta.messengerlite.afad_wait",
-				Instructions: b.AFADNotification,
-				DisplayAndWaitParams: &bridgev2.LoginDisplayAndWaitParams{
-					Type: bridgev2.LoginDisplayTypeNothing,
-				},
-			}
-			b.AFADDisplayed = true
-		}
-
-	case StateEnteredEmailPasswordAction:
-		_, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
-		if err != nil {
-			if err.Error() == "Invalid username or password" {
-				delete(userInput, "username")
-				delete(userInput, "password")
-				b.LastError = err.Error()
-				b.State = StateEmailPasswordPage
-			} else if strings.Contains(err.Error(), "isn't connected to an account") {
-				delete(userInput, "username")
-				delete(userInput, "password")
-				thing := "username"
-				if strings.Contains("@", userInput["username"]) {
-					thing = "email address"
-				}
-				b.LastError = fmt.Sprintf("That %s is not connected to a Messenger account", thing)
-				b.State = StateEmailPasswordPage
-			} else {
-				return nil, fmt.Errorf("execute %s: %w", b.State, err)
-			}
-		}
-
-	case StateEnteredEmailCodeAction:
-		_, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
-		if err != nil {
-			if strings.HasPrefix(err.Error(), "Please re-enter") {
-				delete(userInput, "email_code")
-				b.LastError = err.Error()
-				b.State = StateEmailCodePage
-			} else {
-				return nil, fmt.Errorf("execute %s: %w", b.State, err)
-			}
-		}
-
-	case StateEnteredTOTPAction:
-		_, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
-		if err != nil {
-			return nil, fmt.Errorf("execute %s: %w", b.State, err)
-		}
-		// Check if a TOTP error was logged by the action. Sort of a hack.
-		if b.LastError != "" {
-			delete(userInput, "totp_code")
-			b.State = StateTOTPPage
-		}
-
-	case StateEnteredSMSAction:
-		_, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
-		if err != nil {
-			return nil, fmt.Errorf("execute %s: %w", b.State, err)
-		}
-		// This uses the same logic as TOTP code submission. Sort of.
-		if b.LastError != "" {
-			delete(userInput, "sms_code")
-			b.State = StateSMSPageAfterSend
-		}
-
-	case StateEnteredWhatsAppAction:
-		_, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
-		if err != nil {
-			return nil, fmt.Errorf("execute %s: %w", b.State, err)
-		}
-		// See above.
-		if b.LastError != "" {
-			delete(userInput, "whatsapp_code")
-			b.State = StateWhatsAppPageAfterSend
-		}
-
-	case StateEnteredBackupCodeAction:
-		_, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
-		if err != nil {
-			return nil, fmt.Errorf("execute %s: %w", b.State, err)
-		}
-		// This is again similar to TOTP handling. We could maybe combine these cases.
-		if b.LastError != "" {
-			delete(userInput, "backup_code")
-			b.State = StateBackupCodePage
-		}
-
-	case StateRedirectToLoginAction, StateRedirectToMFALandingAction, StateChosenMFAAction, StateAFADCompleteAction:
-		_, err := b.CurrentAction.Interpreter.Evaluate(ctx, b.CurrentAction.Action())
-		if err != nil {
-			return nil, fmt.Errorf("execute %s: %w", b.State, err)
+			return nil, fmt.Errorf("initial action: %w", err)
 		}
 
 	case StateEmailPasswordPage:
-		if userInput["username"] == "" || userInput["password"] == "" {
+		username := userInput["username"]
+		password := userInput["password"]
+		if username == "" || password == "" {
 			instructions := "Enter your Facebook credentials. The Messenger network will only work with Facebook accounts."
 			if b.LastError != "" {
 				instructions = fmt.Sprintf("%s. %s", b.LastError, instructions)
@@ -876,20 +701,25 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			break
 		}
 
-		if !definitelyNotPhoneNumberRegexp.MatchString(userInput["username"]) {
+		if !definitelyNotPhoneNumberRegexp.MatchString(username) {
 			return nil, ErrLoginPhoneNumber
 		}
 
+		// Set up in case we don't navigate to a new page successfully
+		delete(userInput, "username")
+		delete(userInput, "password")
+		b.LastError = "Facebook rejected that login"
+
 		err = b.CurrentPage.
 			FindDescendant(FilterByAttribute("bk.components.TextInput", "html_name", "email")).
-			FillInput(ctx, b.CurrentPage.Interpreter, userInput["username"])
+			FillInput(ctx, b.CurrentPage.Interpreter, username)
 		if err != nil {
 			return nil, fmt.Errorf("filling email input: %w", err)
 		}
 
 		err = b.CurrentPage.
 			FindDescendant(FilterByAttribute("bk.components.TextInput", "html_name", "password")).
-			FillInput(ctx, b.CurrentPage.Interpreter, userInput["password"])
+			FillInput(ctx, b.CurrentPage.Interpreter, password)
 		if err != nil {
 			return nil, fmt.Errorf("filling password input: %w", err)
 		}
@@ -899,11 +729,23 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			FindContainingButton().
 			TapButton(ctx, b.CurrentPage.Interpreter)
 		if err != nil {
-			return nil, fmt.Errorf("tapping login button: %w", err)
+			log.Debug().Err(err).Msg("Got error from username/password submission")
+			if strings.Contains(err.Error(), "Invalid username or password") {
+				b.LastError = "Invalid username or password"
+			} else if strings.Contains(err.Error(), "isn't connected to an account") {
+				thing := "username"
+				if strings.Contains("@", username) {
+					thing = "email address"
+				}
+				b.LastError = fmt.Sprintf("That %s is not connected to a Messenger account", thing)
+			} else {
+				return nil, fmt.Errorf("tapping login button: %w", err)
+			}
 		}
 
 	case StateEmailCodePage:
-		if userInput["email_code"] == "" {
+		emailCode := userInput["email_code"]
+		if emailCode == "" {
 			instructions := b.getCodeInstructions()
 			if b.LastError != "" {
 				instructions = fmt.Sprintf(
@@ -925,6 +767,10 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			break
 		}
 
+		// Set up in case we don't navigate to a new page successfully
+		delete(userInput, "email_code")
+		b.LastError = "Facebook rejected that code"
+
 		err := b.CurrentPage.
 			FindDescendant(func(comp *BloksTreeComponent) bool {
 				if comp.ComponentID != "bk.components.TextInput" {
@@ -934,7 +780,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 					"bk.components.AccessibilityExtension", "label", "Enter code",
 				)) != nil
 			}).
-			FillInput(ctx, b.CurrentPage.Interpreter, userInput["email_code"])
+			FillInput(ctx, b.CurrentPage.Interpreter, emailCode)
 		if err != nil {
 			return nil, fmt.Errorf("filling email code input: %w", err)
 		}
@@ -944,11 +790,17 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			FindContainingButton().
 			TapButton(ctx, b.CurrentPage.Interpreter)
 		if err != nil {
-			return nil, fmt.Errorf("tapping continue: %w", err)
+			log.Debug().Err(err).Msg("Got error from email code submission")
+			if strings.Contains(err.Error(), "Please re-enter") {
+				// retry
+			} else {
+				return nil, fmt.Errorf("tapping continue: %w", err)
+			}
 		}
 
 	case StateBackupCodePage:
-		if userInput["backup_code"] == "" {
+		backupCode := userInput["backup_code"]
+		if backupCode == "" {
 			instructions := "Enter one of your two-factor backup codes."
 			if b.LastError != "" {
 				instructions = fmt.Sprintf(
@@ -970,6 +822,10 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			break
 		}
 
+		// Set up in case we don't navigate to a new page successfully
+		delete(userInput, "backup_code")
+		b.LastError = "Facebook rejected that code"
+
 		err := b.CurrentPage.
 			FindDescendant(func(comp *BloksTreeComponent) bool {
 				if comp.ComponentID != "bk.components.TextInput" {
@@ -979,7 +835,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 					"bk.components.AccessibilityExtension", "label", "Code",
 				)) != nil
 			}).
-			FillInput(ctx, b.CurrentPage.Interpreter, userInput["backup_code"])
+			FillInput(ctx, b.CurrentPage.Interpreter, backupCode)
 		if err != nil {
 			return nil, fmt.Errorf("filling backup code input: %w", err)
 		}
@@ -1065,8 +921,8 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			}
 
 			instructions := "Facebook requires solving a captcha"
-			if b.NumCaptchaAttempts > 0 {
-				instructions = "Facebook rejected that captcha solution"
+			if b.LastError != "" {
+				instructions = b.LastError
 			}
 			step = &bridgev2.LoginStep{
 				Type:         bridgev2.LoginStepTypeUserInput,
@@ -1103,6 +959,10 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			break
 		}
 
+		// Set up in case we don't navigate to a new page successfully
+		delete(userInput, "captcha_code")
+		b.LastError = "Facebook rejected that captcha solution"
+
 		err := b.CurrentPage.
 			FindDescendant(func(comp *BloksTreeComponent) bool {
 				if comp.ComponentID != "bk.components.TextInput" {
@@ -1112,7 +972,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 					"bk.components.AccessibilityExtension", "label", "Enter characters",
 				)) != nil
 			}).
-			FillInput(ctx, b.CurrentPage.Interpreter, userInput["captcha_code"])
+			FillInput(ctx, b.CurrentPage.Interpreter, captchaCode)
 		if err != nil {
 			return nil, fmt.Errorf("filling captcha code input: %w", err)
 		}
@@ -1122,10 +982,19 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			FindContainingButton().
 			TapButton(ctx, b.CurrentPage.Interpreter)
 		if err != nil {
+			// The entrypoint_async RPC is sometimes rejected with a generic "server
+			// error field_exception" response when transitioning from the captcha page
+			// to the MFA landing page. The error can be reproduced on the official
+			// Messenger iOS app so it is not a bridge issue. Entering the wrong captcha
+			// produces a different, non-error response - so we know there is nothing
+			// the user could do to cause this, it is purely Meta's fault.
+			if strings.Contains(err.Error(), "Query Error") {
+				return nil, ErrLoginUninformative
+			}
 			return nil, fmt.Errorf("tapping continue: %w", err)
 		}
 
-	case StateMFALandingPage, StatePossibleMandatoryAFADPAge:
+	case StateMFALandingPage:
 		btn := b.CurrentPage.
 			FindDescendant(FilterByAttribute("bk.data.TextSpan", "text", "Try another way")).
 			FindContainingButton()
@@ -1133,7 +1002,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 		// tell until we see whether or not there is a button that would take us to the MFA
 		// method selection page. If there is, we'll follow it like in the non-AP case,
 		// otherwise we'll just treat this as a mandatory AFAD page.
-		if btn == nil && b.State == StatePossibleMandatoryAFADPAge {
+		if btn == nil {
 			b.State = StateAFADPage
 			break
 		}
@@ -1223,7 +1092,8 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 		}
 
 	case StateTOTPPage:
-		if userInput["totp_code"] == "" {
+		totpCode := userInput["totp_code"]
+		if totpCode == "" {
 			instructions := "Enter a six-digit code from your authenticator app"
 			if b.LastError != "" {
 				instructions = fmt.Sprintf(
@@ -1244,6 +1114,10 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			break
 		}
 
+		// Set up in case we don't navigate to a new page successfully
+		delete(userInput, "totp_code")
+		b.LastError = "Facebook rejected that code"
+
 		err := b.CurrentPage.
 			FindDescendant(func(comp *BloksTreeComponent) bool {
 				if comp.ComponentID != "bk.components.TextInput" {
@@ -1253,7 +1127,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 					"bk.components.AccessibilityExtension", "label", "Code",
 				)) != nil
 			}).
-			FillInput(ctx, b.CurrentPage.Interpreter, userInput["totp_code"])
+			FillInput(ctx, b.CurrentPage.Interpreter, totpCode)
 		if err != nil {
 			return nil, fmt.Errorf("filling mfa code input: %w", err)
 		}
@@ -1291,9 +1165,33 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			}
 		}
 
-	case StateAFADWait:
-		time.Sleep(b.AFADInterval)
-		b.State = StateAFADPage
+		if b.State != StateAFADPage {
+			break
+		}
+
+		if b.AFADInterval <= 0 {
+			return nil, fmt.Errorf("no AFAD timer scheduled")
+		}
+
+		// Only display the login step once, keep polling in background
+		step = &bridgev2.LoginStep{
+			Type:         bridgev2.LoginStepTypeDisplayAndWait,
+			StepID:       "fi.mau.meta.messengerlite.afad_wait",
+			Instructions: b.AFADNotification,
+			DisplayAndWaitParams: &bridgev2.LoginDisplayAndWaitParams{
+				Type: bridgev2.LoginDisplayTypeNothing,
+			},
+		}
+		b.State = StateAFADPageWaiting
+
+	case StateAFADPageWaiting:
+		for b.State == StateAFADPageWaiting {
+			time.Sleep(b.AFADInterval)
+			err := b.AFADCallback()
+			if err != nil {
+				return nil, fmt.Errorf("AFAD callback: %w", err)
+			}
+		}
 
 	case StateOAuthPage:
 		return nil, fmt.Errorf("can't handle Google OAuth yet")
@@ -1310,8 +1208,12 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			}
 		}
 
+		// Running the on_mount handlers should have triggered a code to be sent.
+		b.State = StateSMSPageAfterSend
+
 	case StateSMSPageAfterSend:
-		if userInput["sms_code"] == "" {
+		smsCode := userInput["sms_code"]
+		if smsCode == "" {
 			instructions := b.getCodeInstructions()
 			if b.LastError != "" {
 				instructions = fmt.Sprintf(
@@ -1332,6 +1234,10 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			break
 		}
 
+		// Set up in case we don't navigate to a new page successfully
+		delete(userInput, "sms_code")
+		b.LastError = "Facebook rejected that code"
+
 		err := b.CurrentPage.
 			FindDescendant(func(comp *BloksTreeComponent) bool {
 				if comp.ComponentID != "bk.components.TextInput" {
@@ -1341,7 +1247,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 					"bk.components.AccessibilityExtension", "label", "Code",
 				)) != nil
 			}).
-			FillInput(ctx, b.CurrentPage.Interpreter, userInput["sms_code"])
+			FillInput(ctx, b.CurrentPage.Interpreter, smsCode)
 		if err != nil {
 			return nil, fmt.Errorf("filling sms code input: %w", err)
 		}
@@ -1366,8 +1272,12 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			}
 		}
 
+		// Running the on_mount handlers should have triggered a code to be sent.
+		b.State = StateWhatsAppPageAfterSend
+
 	case StateWhatsAppPageAfterSend:
-		if userInput["whatsapp_code"] == "" {
+		whatsAppCode := userInput["whatsapp_code"]
+		if whatsAppCode == "" {
 			instructions := b.getCodeInstructions()
 			if b.LastError != "" {
 				instructions = fmt.Sprintf(
@@ -1388,6 +1298,10 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			break
 		}
 
+		// Set up in case we don't navigate to a new page successfully
+		delete(userInput, "whatsapp_code")
+		b.LastError = "Facebook rejected that code"
+
 		err := b.CurrentPage.
 			FindDescendant(func(comp *BloksTreeComponent) bool {
 				if comp.ComponentID != "bk.components.TextInput" {
@@ -1397,7 +1311,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 					"bk.components.AccessibilityExtension", "label", "Code",
 				)) != nil
 			}).
-			FillInput(ctx, b.CurrentPage.Interpreter, userInput["whatsapp_code"])
+			FillInput(ctx, b.CurrentPage.Interpreter, whatsAppCode)
 		if err != nil {
 			return nil, fmt.Errorf("filling whatsapp code input: %w", err)
 		}
@@ -1414,13 +1328,19 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 		return nil, fmt.Errorf("unexpected state %s", b.State)
 	}
 	if b.State == prevState {
-		if step == nil {
-			return nil, fmt.Errorf("handling %s failed to advance flow", prevState)
-		} else {
+		if step != nil {
 			log.Debug().Str("cur_state", string(b.State)).Any("steps", step).Msg("Requested user input")
+		} else if b.LastError != "" {
+			log.Debug().Str("cur_state", string(b.State)).Str("last_error", b.LastError).Msg("Got intra-screen error, remaining in current state")
+		} else {
+			return nil, fmt.Errorf("handling %s failed to advance flow", prevState)
 		}
 	} else {
 		log.Debug().Str("old_state", string(prevState)).Str("new_state", string(b.State)).Msg("Transitioned login step")
+
+		// Ignore LastError, which is only used for signaling an error within the current
+		// page and can be ignored once we move to a new page.
+		b.LastError = ""
 	}
 	return step, nil
 }

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -466,6 +466,13 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 				}
 				action = &script.AST
 			}
+			// Action payload doesn't include a new page, but it might include some
+			// extra payloads or scripts, we need to merge those in.
+			interp, err := NewInterpreter(ctx, bundle, b.Bridge, b.CurrentPage.GetInterpreter())
+			if err != nil {
+				return nil, fmt.Errorf("merging interpreter with new action")
+			}
+			b.CurrentPage.Interpreter = interp
 			return action, nil
 		},
 		DisplayNewScreen: func(ctx context.Context, name string, page *BloksBundle) error {
@@ -665,9 +672,11 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			return nil, fmt.Errorf("rpc %s: %w", rpc, err)
 		}
 
-		// Arguably this is a bit wrong? We don't save this interpreter anywhere, and end up
-		// not having a CurrentPage interpreter in the initial DisplayNewScreen call, so it
-		// gets constructed from scratch. But this seems like it's working fine for now.
+		// Set up the action bundle as if it's the "current page", just so we have this
+		// variable non-null and can reference it later. Even though it's really an action,
+		// not a page.
+		b.CurrentPage = action
+
 		err = action.SetupInterpreter(ctx, b.Bridge, nil)
 		if err != nil {
 			return nil, fmt.Errorf("setup %s interpreter: %w", b.State, err)

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -551,7 +551,7 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 			b.DisplayedURL = url
 			return nil
 		},
-		HandleVariableChange: func(name string, value *BloksScriptLiteral) error {
+		HandleVariableChange: func(ctx context.Context, name string, value *BloksScriptLiteral) error {
 			switch name {
 			case "BLOKS_TWO_STEP_VERIFICATION_ENTER_CODE:error_message":
 				switch b.State {

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -1014,6 +1014,15 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			if strings.Contains(err.Error(), "Query Error") {
 				return nil, ErrLoginUninformative
 			}
+			// Sometimes just for spice, they will throw you a "Wrong Credentials" /
+			// "Invalid username or password" error here, even though what you submitted
+			// was a captcha rather than a username or password. And of course this
+			// happens even if you gave the correct password. If you actually gave a
+			// wrong password, it would have errored out at the password step, if we get
+			// the same error here, it means the Zuck says no.
+			if strings.Contains(err.Error(), "Invalid username or password") {
+				return nil, ErrLoginUninformative
+			}
 			return nil, fmt.Errorf("tapping continue: %w", err)
 		}
 

--- a/pkg/messagix/bloks/tree.go
+++ b/pkg/messagix/bloks/tree.go
@@ -354,7 +354,9 @@ func redactString(s string) string {
 			break
 		}
 	}
-	digest := sha256.New().Sum([]byte(s))
+	h := sha256.New()
+	h.Write([]byte(s))
+	digest := h.Sum(nil)
 	return fmt.Sprintf("%sredacted_%dchar_%s_%s", prefix, len(s), stringType, hex.EncodeToString(digest[:4]))
 }
 

--- a/pkg/messagix/bloks/tree.go
+++ b/pkg/messagix/bloks/tree.go
@@ -860,7 +860,7 @@ func (bs BloksTreeScript) MarshalJSON() ([]byte, error) {
 }
 
 func (bs *BloksTreeScript) Unminify(m *Unminifier, parent *BloksTreeComponent) {
-	bs.AST.Unminify(m)
+	bs.AST.Content.Unminify(m)
 }
 
 func (bst *BloksTreeScript) Parse(code string) error {
@@ -869,7 +869,7 @@ func (bst *BloksTreeScript) Parse(code string) error {
 }
 
 func (bst *BloksTreeScript) Print(w io.Writer, indent string) error {
-	return bst.AST.Print(w, indent)
+	return bst.AST.Content.Print(w, indent)
 }
 
 func (bst *BloksTreeScript) PrintHTML(w io.Writer, indent string) error {
@@ -881,7 +881,7 @@ func (bst *BloksTreeScript) Redact() {
 	if bst == nil {
 		return
 	}
-	bst.AST.Redact()
+	bst.AST.Content.Redact()
 }
 
 type BloksTreeScriptSet struct {

--- a/pkg/messagix/bloks/tree.go
+++ b/pkg/messagix/bloks/tree.go
@@ -39,8 +39,8 @@ func (bb *BloksBundle) Action() *BloksScriptNode {
 	return &bb.Layout.Payload.Action.AST
 }
 
-func (bb *BloksBundle) SetupInterpreter(ctx context.Context, br *InterpBridge, prev *Interpreter) error {
-	interp, err := NewInterpreter(ctx, bb, br, prev)
+func (bb *BloksBundle) SetupInterpreter(ctx context.Context, br *InterpBridge, prev *Interpreter, clearLocals bool) error {
+	interp, err := NewInterpreter(ctx, bb, br, prev, clearLocals)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For an overview of the new abstractions, see the large code comment near the top of `selenium.go` changes.

* Split `DoRPC` into `DoPageRPC` and `DoActionRPC` on interpreter bridge.
* Interpreter is now responsible for executing action callbacks, and always does so. Previous code was only doing it manually in some cases which was breaking captcha rotation.
* Removed action states from the flow graph entirely. Many fewer enum values now.
* Stop enforcing graph transitions to happen on specific edges. Only do enough book-keeping to reliably know what page is currently being displayed. Increases robustness. If something goes wonky the logs will still have enough information to see what.
* Kill almost all special-case handling of specific flow states. Basically only AFAD has any special logic remaining, and even that is relatively minimal.
* AFAD actually uses the timer callback now instead of just continually refreshing the on_appear extensions.
* Consistent recoverable error handling. Fixed a couple of inconsistencies as part of implementing the new approach outlined in the comment.

Generally - simplify, simplify, simplify. It's not that many fewer lines of code but trust me it's way easier to understand and reason about individual parts now, without having to trace flow through unrelated parts of the code.

After the basic refactoring, fix up bugs and rough edges that are easier to address now:

* Add implementations of some new Bloks functions, that were always present but were incorrectly not being called before because we weren't consistently invoking action callbacks.
* Differentiate `BloksScriptNode` from `BloksScriptNodeContent` so that the type checker will actually error out if you use the wrong one.
* Handle redirection to the `com.bloks.www.caa.assistive_login_confirmation` screen with a proper recoverable error message.
* Fix semantics of the implementation for `bk.action.mins.GetByValOr`, which was falling back to default on `false`, not just `null`, preventing captcha error responses with `"success": false` from being processed correctly.
* Add context parameter to `HandleVariableChange`, unused but helpful for debugging.
* Fix hash calculation, which was misusing the sha256 api and not actually hashing the contents. Not a security issue as it was still impossible to recover the unredacted data, but less helpful for debugging.
* Carry over local variables from page to action contexts.
* Correctly share variable context between action callback and the rest of the page.
