### PR TITLE
capabilities: add mp4 to gif instagram capabilities

### DIFF
--- a/pkg/connector/capabilities.go
+++ b/pkg/connector/capabilities.go
@@ -209,6 +209,15 @@ func init() {
 	igCaps.MessageRequest = &event.MessageRequestFeatures{
 		AcceptWithButton: event.CapLevelFullySupported,
 	}
+	igCaps.File[event.CapMsgGIF] = &event.FileFeatures{
+		MimeTypes: map[string]event.CapabilitySupportLevel{
+			"image/gif": event.CapLevelFullySupported,
+			"video/mp4": event.CapLevelFullySupported,
+		},
+		Caption:          event.CapLevelDropped,
+		MaxCaptionLength: MaxTextLength,
+		MaxSize:          MaxImageSize,
+	}
 	igCaps.ID += "+instagram"
 	igCapsGroup = igCaps.Clone()
 	igCapsGroup.ID += "+instagram-group"


### PR DESCRIPTION
Adds `video/mp4` to supported mime types for GIF messages. Instagram iOS and Web sends them as MP4s.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
