### PR TITLE
connector: More proxy options

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -227,7 +227,7 @@ func (m *MetaClient) connectWithRetry(retryCtx, ctx context.Context, attempts in
 	} else {
 		zerolog.Ctx(ctx).Debug().Msg("No saved reconnection state")
 	}
-	if m.Main.Config.GetProxyFrom != "" || m.Main.Config.Proxy != "" {
+	if m.Main.Config.ProxyOther && (m.Main.Config.GetProxyFrom != "" || m.Main.Config.Proxy != "") {
 		cli.GetNewProxy = m.Main.getProxy
 		if !cli.UpdateProxy("connect") {
 			m.UserLogin.BridgeState.Send(status.BridgeState{

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -25,10 +25,12 @@ type Config struct {
 
 	AllowMessengerComOnFB bool `yaml:"allow_messenger_com_on_fb"`
 
-	Proxy        string `yaml:"proxy"`
-	GetProxyFrom string `yaml:"get_proxy_from"`
-	ProxyMedia   bool   `yaml:"proxy_media"`
-	ProxyE2EE    bool   `yaml:"proxy_e2ee"`
+	Proxy              string `yaml:"proxy"`
+	GetProxyFrom       string `yaml:"get_proxy_from"`
+	ProxyMedia         bool   `yaml:"proxy_media"`
+	ProxyE2EE          bool   `yaml:"proxy_e2ee"`
+	ProxyMessengerLite bool   `yaml:"proxy_messenger_lite"`
+	ProxyOther         bool   `yaml:"proxy_other"`
 
 	DisableXMABackfill bool `yaml:"disable_xma_backfill"`
 	DisableXMAAlways   bool `yaml:"disable_xma_always"`
@@ -91,6 +93,8 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Str|up.Null, "get_proxy_from")
 	helper.Copy(up.Bool, "proxy_media")
 	helper.Copy(up.Bool, "proxy_e2ee")
+	helper.Copy(up.Bool, "proxy_messenger_lite")
+	helper.Copy(up.Bool, "proxy_other")
 	helper.Copy(up.Int, "min_full_reconnect_interval_seconds")
 	helper.Copy(up.Int, "force_refresh_interval_seconds")
 	helper.Copy(up.Bool, "cache_connection_state")

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -28,6 +28,10 @@ get_proxy_from:
 proxy_media: false
 # Should E2EE messages be proxied too?
 proxy_e2ee: false
+# Should Messenger Lite login traffic be proxied?
+proxy_messenger_lite: true
+# Should other traffic, not configured here, be proxied?
+proxy_other: true
 # Minimum interval between full reconnects in seconds, default is 1 hour
 min_full_reconnect_interval_seconds: 3600
 # Interval to force refresh the connection (full reconnect), default is 20 hours. Set 0 to disable force refreshes.

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -223,9 +223,9 @@ var (
 	ErrLoginUnknown          = bridgev2.RespError{ErrCode: "M_UNKNOWN", Err: "Internal error logging in", StatusCode: http.StatusInternalServerError}
 )
 
-func getMessagixClient(log zerolog.Logger, conn *MetaConnector, c *cookies.Cookies) (*messagix.Client, error) {
+func getMessagixClient(log zerolog.Logger, conn *MetaConnector, c *cookies.Cookies, useProxy bool) (*messagix.Client, error) {
 	client := messagix.NewClient(c, log, conn.getMessagixConfig())
-	if conn.Config.GetProxyFrom != "" || conn.Config.Proxy != "" {
+	if useProxy && (conn.Config.GetProxyFrom != "" || conn.Config.Proxy != "") {
 		client.GetNewProxy = conn.getProxy
 		if !client.UpdateProxy("login") {
 			return nil, fmt.Errorf("failed to update proxy")
@@ -327,7 +327,7 @@ func (m *MetaCookieLogin) SubmitCookies(ctx context.Context, strCookies map[stri
 	}
 
 	log := m.User.Log.With().Str("component", "messagix").Logger()
-	client, err := getMessagixClient(log, m.Main, c)
+	client, err := getMessagixClient(log, m.Main, c, m.Main.Config.ProxyOther)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (m *MetaNativeLogin) Start(ctx context.Context) (*bridgev2.LoginStep, error
 	fakeCookies := &cookies.Cookies{
 		Platform: m.Mode,
 	}
-	client, err := getMessagixClient(log, m.Main, fakeCookies)
+	client, err := getMessagixClient(log, m.Main, fakeCookies, m.Main.Config.ProxyMessengerLite)
 	if err != nil {
 		return nil, err
 	}
@@ -383,11 +383,19 @@ func (m *MetaNativeLogin) proceed(ctx context.Context, userInput map[string]stri
 		return step, nil
 	}
 
-	_ = newCookies
+	// Create a new messagix.Client here so that we can change
+	// proxy settings between the login and post-login.
+	fakeCookies := &cookies.Cookies{
+		Platform: m.Mode,
+	}
+	newClient, err := getMessagixClient(log, m.Main, fakeCookies, m.Main.Config.ProxyOther)
+	if err != nil {
+		return nil, err
+	}
 
-	m.SavedClient.GetCookies().UpdateValues(newCookies.GetAll())
+	newClient.GetCookies().UpdateValues(newCookies.GetAll())
 
-	step, err = loginWithCookies(ctx, log, m.SavedClient, m.User, m.Main, newCookies)
+	step, err = loginWithCookies(ctx, log, newClient, m.User, m.Main, newCookies)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/messagix/client.go
+++ b/pkg/messagix/client.go
@@ -47,15 +47,14 @@ type Client struct {
 	Logger        zerolog.Logger
 	Platform      types.Platform
 
-	http              *http.Client
-	httpSettings      exhttp.ClientSettings
-	loginHttpSettings exhttp.ClientSettings
-	proxyAddr         string
-	socket            *Socket
-	dgwSocket         *dgw.Socket
-	eventHandler      EventHandler
-	configs           *Configs
-	syncManager       *SyncManager
+	http         *http.Client
+	httpSettings exhttp.ClientSettings
+	proxyAddr    string
+	socket       *Socket
+	dgwSocket    *dgw.Socket
+	eventHandler EventHandler
+	configs      *Configs
+	syncManager  *SyncManager
 
 	cookies         *cookies.Cookies
 	httpProxy       func(*http.Request) (*url.URL, error)

--- a/pkg/messagix/client.go
+++ b/pkg/messagix/client.go
@@ -47,14 +47,15 @@ type Client struct {
 	Logger        zerolog.Logger
 	Platform      types.Platform
 
-	http         *http.Client
-	httpSettings exhttp.ClientSettings
-	proxyAddr    string
-	socket       *Socket
-	dgwSocket    *dgw.Socket
-	eventHandler EventHandler
-	configs      *Configs
-	syncManager  *SyncManager
+	http              *http.Client
+	httpSettings      exhttp.ClientSettings
+	loginHttpSettings exhttp.ClientSettings
+	proxyAddr         string
+	socket            *Socket
+	dgwSocket         *dgw.Socket
+	eventHandler      EventHandler
+	configs           *Configs
+	syncManager       *SyncManager
 
 	cookies         *cookies.Cookies
 	httpProxy       func(*http.Request) (*url.URL, error)


### PR DESCRIPTION
New config options for controlling what requests use the configured proxy in a more fine-grained manner. No change to default behavior.