### PR TITLE
Retry message lookup in direct media Download to fix insert race

### DIFF
--- a/pkg/connector/directmedia.go
+++ b/pkg/connector/directmedia.go
@@ -35,11 +35,27 @@ func (m *MetaConnector) Download(ctx context.Context, mediaID networkid.MediaID,
 	}
 	zerolog.Ctx(ctx).Trace().Any("mediaInfo", mediaInfo).Any("err", err).Msg("download direct media")
 
+	lookupMessage := func() (*database.Message, error) {
+		if mediaInfo.PartID == "" {
+			return m.Bridge.DB.Message.GetFirstPartByID(ctx, mediaInfo.UserID, mediaInfo.MessageID)
+		}
+		return m.Bridge.DB.Message.GetPartByID(ctx, mediaInfo.UserID, mediaInfo.MessageID, mediaInfo.PartID)
+	}
+
 	var msg *database.Message
-	if mediaInfo.PartID == "" {
-		msg, err = m.Bridge.DB.Message.GetFirstPartByID(ctx, mediaInfo.UserID, mediaInfo.MessageID)
-	} else {
-		msg, err = m.Bridge.DB.Message.GetPartByID(ctx, mediaInfo.UserID, mediaInfo.MessageID, mediaInfo.PartID)
+	msg, err = lookupMessage()
+	// The client may request media for an event before the bridge has finished
+	// inserting the message row: bridgev2's sendConvertedMessage sends the Matrix
+	// event before persisting the message part, and with a local bridge the client
+	// auto-downloads within milliseconds. Retry the lookup briefly instead of
+	// failing hard so the race resolves itself once the insert lands.
+	for attempt := 0; err == nil && msg == nil && attempt < 10; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+		msg, err = lookupMessage()
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

Inbound local-bridge media downloads race the bridge's own DB insert:

1. bridgev2's `sendConvertedMessage` sends the Matrix event (`intent.SendMessage`) **before** persisting the message part (`portal.Bridge.DB.Message.Insert`). This ordering can't easily be flipped because the message row depends on the MXID returned by the send.
2. With a local bridge, the event reaches the client in-process within milliseconds and the client auto-downloads the `localmxc://` direct-media URL.
3. `Download()` in `pkg/connector/directmedia.go` looks up the message part in the bridge DB, finds nothing, and returns `fmt.Errorf("message not found")`.
4. The client treats that as terminal (`canRetry: false`), so the attachment bubble shows "Something went wrong" until the user manually taps it (which re-downloads and succeeds).

## Fix

Replace the single message-part lookup in `Download()` with a bounded retry loop: retry the lookup while `err == nil && msg == nil`, up to 10 attempts of 200 ms each, respecting `ctx` cancellation, before returning "message not found". The row is written milliseconds after the event is dispatched, so a few short retries close the race.

- No behavior change when the row already exists (the overwhelmingly common case).
- A genuine DB error short-circuits immediately (no pointless retries).
- Worst-case added latency (~2 s) only on the otherwise-failing path.
- Fixes the race for all Meta-connector consumers (local-instagram/facebook, cloud variants), single- and multi-image alike.

## Out of scope (follow-up)

A secondary, defense-in-depth fix lives in the beeper monorepo (not this repo): classify `message not found` from a local-bridge direct-media download as **retryable** (`canRetry: true`) in the FFI/SDK error-mapping layer, so the UI can self-heal even if the bridge-side window is ever exceeded. That change requires locating the mapping site in the monorepo and is tracked as a follow-up. The bridge-side retry here is sufficient to resolve the reported symptom on its own.

## Linear

https://linear.app/beeper/issue/BIOS-32186