### PR TITLE
msgconv: reject stale incoming disappearing-message settings by timestamp

### DIFF
--- a/pkg/msgconv/from-whatsapp.go
+++ b/pkg/msgconv/from-whatsapp.go
@@ -706,8 +706,9 @@ func (mc *MessageConverter) WhatsAppToMatrix(
 		if cm.Disappear.Timer == 0 {
 			cm.Disappear.Type = event.DisappearingTypeNone
 		}
-		if evt.Message != nil && cm.Disappear != portal.Disappear && disappear.EphemeralSettingTimestamp != nil {
-			portal.Metadata.(*metaid.PortalMetadata).EphemeralSettingTimestamp = *disappear.EphemeralSettingTimestamp
+		meta := portal.Metadata.(*metaid.PortalMetadata)
+		if evt.Message != nil && cm.Disappear != portal.Disappear && disappear.EphemeralSettingTimestamp != nil && *disappear.EphemeralSettingTimestamp > meta.EphemeralSettingTimestamp {
+			meta.EphemeralSettingTimestamp = *disappear.EphemeralSettingTimestamp
 			portal.UpdateDisappearingSetting(ctx, cm.Disappear, bridgev2.UpdateDisappearingSettingOpts{
 				Sender:     intent,
 				Timestamp:  evt.Info.Timestamp,


### PR DESCRIPTION
Only apply an incoming setting when its `EphemeralSettingTimestamp` is **strictly newer** than the stored portal timestamp.

Linear: https://linear.app/beeper/issue/PLAT-36482