### PR TITLE
BIOS-33821: Fix Facebook contact disappearing from SNC once a DM exists

### DIFF
--- a/pkg/connector/startchat.go
+++ b/pkg/connector/startchat.go
@@ -229,7 +229,7 @@ func (m *MetaClient) SearchUsers(ctx context.Context, search string) ([]*bridgev
 	users := make([]*bridgev2.ResolveIdentifierResponse, 0)
 
 	for _, result := range resp.LSInsertSearchResult {
-		if result.ThreadType == table.ONE_TO_ONE && result.CanViewerMessage && result.GetFBID() != 0 {
+		if result.ThreadType.IsOneToOne() && result.CanViewerMessage && result.GetFBID() != 0 {
 			userID := metaid.MakeUserID(result.GetFBID())
 			ghost, _ := m.Main.Bridge.GetGhostByID(ctx, userID)
 			users = append(users, &bridgev2.ResolveIdentifierResponse{

--- a/pkg/messagix/table/search.go
+++ b/pkg/messagix/table/search.go
@@ -67,7 +67,10 @@ func (lsisr *LSInsertSearchResult) GetAvatarURL() string {
 }
 
 func (lsisr *LSInsertSearchResult) GetFBID() int64 {
-	if lsisr.ThreadType == ONE_TO_ONE {
+	if lsisr.OtherUserId != 0 {
+		return lsisr.OtherUserId
+	}
+	if lsisr.ThreadType.IsOneToOne() {
 		fbid, _ := strconv.ParseInt(lsisr.ResultId, 10, 64)
 		return fbid
 	}


### PR DESCRIPTION
## Problem

On Facebook, once a DM exists with a contact, that contact disappears from Start New Chat search / Connections. Searching the name without spaces makes them reappear.

## Root cause

Messenger DMs are created as `ENCRYPTED_OVER_WA_ONE_TO_ONE` (ThreadType 15), but `SearchUsers` only surfaced plain `ONE_TO_ONE` (type 1) results. Once a DM exists, Meta returns the contact as a type-15 existing-thread result, which was filtered out twice (the connector filter and `GetFBID()` returning 0 for non-type-1).

## Fix

- `pkg/connector/startchat.go`: relax the `SearchUsers` filter to accept all 1:1 thread types via `ThreadType.IsOneToOne()` (still gated on `CanViewerMessage` and `GetFBID() != 0`).
- `pkg/messagix/table/search.go`: `GetFBID()` now returns `OtherUserId` when set, falling back to parsing `ResultId` for any 1:1 thread type.

## Verification

`go build` and `go vet` pass on the changed packages. Direct on-bridge repro (search a contact with an existing Messenger E2EE DM, confirm it now appears) recommended before merge — the raw type-15 search response was inferred from the struct + the with/without-space asymmetry, not captured in trace logs.