### PR TITLE
backfill: recover never-bridged messages in forward backfill

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -318,16 +318,10 @@ func (m *MetaClient) wrapBackfillEvents(ctx context.Context, portal *bridgev2.Po
 		}
 		return false
 	})
-	if anchor != nil {
-		if forward {
-			upsert.Messages = slices.DeleteFunc(upsert.Messages, func(message *table.WrappedMessage) bool {
-				return message.TimestampMs <= anchor.Timestamp.UnixMilli()
-			})
-		} else {
-			upsert.Messages = slices.DeleteFunc(upsert.Messages, func(message *table.WrappedMessage) bool {
-				return message.TimestampMs >= anchor.Timestamp.UnixMilli()
-			})
-		}
+	if anchor != nil && !forward {
+		upsert.Messages = slices.DeleteFunc(upsert.Messages, func(message *table.WrappedMessage) bool {
+			return message.TimestampMs >= anchor.Timestamp.UnixMilli()
+		})
 	}
 	wrappedMessages := make([]*bridgev2.BackfillMessage, len(upsert.Messages))
 	for i, msg := range upsert.Messages {
@@ -371,5 +365,9 @@ func (m *MetaClient) wrapBackfillEvents(ctx context.Context, portal *bridgev2.Po
 		Messages: wrappedMessages,
 		HasMore:  upsert.Range.HasMoreBefore,
 		MarkRead: upsert.MarkRead,
+		// Forward backfill can fetch a range covering never-bridged mid-timeline messages (older than
+		// the anchor) that a reconnect snapshot skipped. Deduplicate by message ID instead of trimming
+		// on timestamp so those messages are recovered while genuine duplicates are still dropped.
+		AggressiveDeduplication: forward,
 	}
 }


### PR DESCRIPTION
## Problem

Messenger messages that arrive while the bridge is offline can be permanently lost. A reconnect snapshot advances the Meta sync cursor past skipped threads, so their mid-timeline messages are never bridged. A later forward backfill covering the gap then dropped those messages in because `ts <= anchor.Timestamp`, so the gap was lost forever.

## Change

- Remove the forward timestamp `DeleteFunc(ts <= anchor)` in `wrapBackfillEvents`.
- Set `AggressiveDeduplication: forward` on the returned `FetchMessagesResponse` so bridgev2 deduplicates by message ID — dropping already-bridged messages while retaining never-bridged ones older than the anchor.
- Keep the backward timestamp trim unchanged.

## Regression risk (please scrutinize)

The removed forward timestamp trim was an intentional dedup guard. Dedup now relies on bridgev2's ID-based pass. Meta message IDs are deterministic from the network `MessageId` and the live and backfill paths store under the same ID, so already-bridged messages are still found and dropped; intra-batch dupes are handled by the existing `CompactFunc`; in-flight messages are covered by the TxnID pending check. Assessed acceptable (high confidence), but maintainer review of the dedup assumption is requested. New minor cost: one indexed `GetFirstPartByID` lookup per forward-backfill message.

## Cross-repo dependency

Requires mautrix/go#517 (skips the forward timestamp prefix-trim in `cutoffMessages` when `AggressiveDeduplication` is set). Without that change this PR has no effect, since bridgev2 would re-trim the retained messages by timestamp. Merge order: mautrix/go first, then bump the dependency here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)