### PR TITLE
startchat: fix contact disappearing from search once a DM exists

### DIFF
--- a/pkg/connector/startchat.go
+++ b/pkg/connector/startchat.go
@@ -229,7 +229,7 @@ func (m *MetaClient) SearchUsers(ctx context.Context, search string) ([]*bridgev
 	users := make([]*bridgev2.ResolveIdentifierResponse, 0)
 
 	for _, result := range resp.LSInsertSearchResult {
-		if result.ThreadType == table.ONE_TO_ONE && result.CanViewerMessage && result.GetFBID() != 0 {
+		if result.ThreadType.IsOneToOne() && result.CanViewerMessage && result.GetFBID() != 0 {
 			userID := metaid.MakeUserID(result.GetFBID())
 			ghost, _ := m.Main.Bridge.GetGhostByID(ctx, userID)
 			users = append(users, &bridgev2.ResolveIdentifierResponse{

--- a/pkg/messagix/table/search.go
+++ b/pkg/messagix/table/search.go
@@ -67,7 +67,10 @@ func (lsisr *LSInsertSearchResult) GetAvatarURL() string {
 }
 
 func (lsisr *LSInsertSearchResult) GetFBID() int64 {
-	if lsisr.ThreadType == ONE_TO_ONE {
+	if lsisr.OtherUserId != 0 {
+		return lsisr.OtherUserId
+	}
+	if lsisr.ThreadType.IsOneToOne() {
 		fbid, _ := strconv.ParseInt(lsisr.ResultId, 10, 64)
 		return fbid
 	}


### PR DESCRIPTION
Messenger DMs are created as ENCRYPTED_OVER_WA_ONE_TO_ONE (type 15), but SearchUsers only surfaced plain ONE_TO_ONE results, so a contact vanished from Start New Chat once a DM existed.

Relax the SearchUsers filter to accept all 1:1 thread types via IsOneToOne(). Make GetFBID() return OtherUserId when set, falling back to ResultId for any 1:1 thread type.
