### PR TITLE
messagix/bloks: improve transient token error message

### DIFF
--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -221,6 +221,7 @@ var (
 	ErrLoginConsent          = bridgev2.RespError{ErrCode: "FI.MAU.META_CONSENT_ERROR", Err: "Consent required, please check the official website or app and then try again", StatusCode: http.StatusBadRequest}
 	ErrLoginCheckpoint       = bridgev2.RespError{ErrCode: "FI.MAU.META_CHECKPOINT_ERROR", Err: "Checkpoint required, please check the official website or app and then try again", StatusCode: http.StatusBadRequest}
 	ErrLoginTokenInvalidated = bridgev2.RespError{ErrCode: "FI.MAU.META_TOKEN_ERROR", Err: "Got logged out immediately", StatusCode: http.StatusBadRequest}
+	ErrLoginTransientToken   = bridgev2.RespError{ErrCode: "FI.MAU.META_TRANSIENT_TOKEN_ERROR", Err: "Login approved but could not be completed automatically, please try again", StatusCode: http.StatusBadRequest}
 	ErrLoginUnknown          = bridgev2.RespError{ErrCode: "M_UNKNOWN", Err: "Internal error logging in", StatusCode: http.StatusInternalServerError}
 )
 
@@ -377,6 +378,8 @@ func (m *MetaNativeLogin) proceed(ctx context.Context, userInput map[string]stri
 		log.Error().Err(err).Msg("Login steps returned error")
 		if errors.As(err, &bloks.CheckpointError{}) {
 			err = ErrLoginCheckpoint
+		} else if errors.Is(err, messagix.ErrTransientTokenLogin) {
+			err = ErrLoginTransientToken
 		}
 		return nil, err
 	}

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -1074,13 +1074,16 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 		methodNames := []string{}
 
 		knownMethods := map[string]bool{
+			"Authentication app": true,
+			"Email":              true,
+			"Text message":       true,
+			"Backup code":        true,
+			"WhatsApp":           true,
+			// Disabled because there's no reasonable way to support this outside of a webview
+			"Verify with Google": false,
+			// Intentionally last because this tends to give transient_token results rather than
+			// cookies directly, which requires a currently unknown extra step.
 			"Notification on another device": true,
-			"Authentication app":             true,
-			"Email":                          true,
-			"Text message":                   true,
-			"Backup code":                    true,
-			"WhatsApp":                       true,
-			"Verify with Google":             false,
 		}
 
 		listItems := b.CurrentPage.FindDescendant(FilterByAttribute(

--- a/pkg/messagix/messengerlite.go
+++ b/pkg/messagix/messengerlite.go
@@ -3,6 +3,7 @@ package messagix
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -18,6 +19,8 @@ import (
 	"go.mau.fi/mautrix-meta/pkg/messagix/types"
 	"go.mau.fi/mautrix-meta/pkg/messagix/useragent"
 )
+
+var ErrTransientTokenLogin = errors.New("login approved but could not be completed automatically, please try logging in again")
 
 type MessengerLiteMethods struct {
 	client *Client
@@ -200,6 +203,7 @@ func (m *MessengerLiteMethods) DoLoginSteps(ctx context.Context, userInput map[s
 		// is two_factor. It depends on the account, not on the MFA method
 		// selected.
 		m.client.Logger.Warn().Msg("Got credential_type transient_token, login will fail")
+		return nil, nil, ErrTransientTokenLogin
 	}
 
 	if len(loginRespPayload.SessionCookies) == 0 {


### PR DESCRIPTION
In most cases retrying seems to work since this is after the approval bit, we're just missing the exchange of token to cookies atm.