### PR TITLE
messagix/bloks: Handle passkey screen

### DIFF
--- a/pkg/messagix/bloks/cmd/main.go
+++ b/pkg/messagix/bloks/cmd/main.go
@@ -48,6 +48,7 @@ var doCaptcha = flag.String("captcha-code", "", "Captcha code to submit")
 var captchaResponse = flag.String("captcha-resp", "", "Bloks response for captcha submission")
 var doWhatsAppNumbers = flag.Bool("whatsapp-numbers", false, "Print the available WhatsApp numbers")
 var selectedWhatsAppNumber = flag.String("whatsapp-number", "", "Pick a WhatsApp number and submit")
+var cancelPasskey = flag.Bool("cancel-passkey", false, "Tap the 'try another way' passkey button")
 
 func main() {
 	err := mainE()
@@ -635,6 +636,14 @@ func mainE() error {
 			TapButton(ctx, interp)
 		if err != nil {
 			return fmt.Errorf("tap continue: %w", err)
+		}
+	} else if *cancelPasskey {
+		btn := bundle.
+			FindDescendant(bloks.FilterByAttribute("bk.data.TextSpan", "text", "Try another way")).
+			FindContainingButton()
+		err := btn.TapButton(ctx, interp)
+		if err != nil {
+			return fmt.Errorf("tapping try another way button: %w", err)
 		}
 	}
 	return nil

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -299,6 +299,7 @@ const (
 	StateChooseNumberPage      BrowserState = "choose-number-page"
 	StateWhatsAppPage          BrowserState = "whatsapp-page"
 	StateWhatsAppPageAfterSend BrowserState = "whatsapp-page-after-send"
+	StatePasskeyPage           BrowserState = "passkey"
 	StateSuccess               BrowserState = "success"
 )
 
@@ -528,6 +529,8 @@ func NewBrowser(cfg *BrowserConfig) *Browser {
 				newState = StateChooseNumberPage
 			case "com.bloks.www.two_step_verification.enter_whatsapp_code":
 				newState = StateWhatsAppPage
+			case "com.bloks.www.ap.passkey_auth":
+				newState = StatePasskeyPage
 			default:
 				return fmt.Errorf("unexpected new screen %s", name)
 			}
@@ -1456,6 +1459,15 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			TapButton(ctx, b.CurrentPage.Interpreter)
 		if err != nil {
 			return nil, fmt.Errorf("tapping continue: %w", err)
+		}
+
+	case StatePasskeyPage:
+		btn := b.CurrentPage.
+			FindDescendant(FilterByAttribute("bk.data.TextSpan", "text", "Try another way")).
+			FindContainingButton()
+		err := btn.TapButton(ctx, b.CurrentPage.Interpreter)
+		if err != nil {
+			return nil, fmt.Errorf("tapping try another way button: %w", err)
 		}
 
 	default:


### PR DESCRIPTION
For now, just cancel out of it and go back to the regular MFA screen.
