### PR TITLE
msgconv/from-instagram: fix panic when replied-to message is missing

### DIFF
--- a/pkg/msgconv/igconv/from-instagram.go
+++ b/pkg/msgconv/igconv/from-instagram.go
@@ -77,8 +77,10 @@ func (mc *MessageConverter) ToMatrix(
 		cm.ReplyTo = &networkid.MessageOptionalPartID{
 			MessageID: metaid.MakeFBMessageID(msg.RepliedToMessageID),
 		}
-		cm.ReplyToUser = metaid.MakeUserID(msg.RepliedToMessage.SenderFBID)
-		cm.ReplyToLogin = metaid.MakeUserLoginID(msg.RepliedToMessage.SenderFBID)
+		if msg.RepliedToMessage != nil {
+			cm.ReplyToUser = metaid.MakeUserID(msg.RepliedToMessage.SenderFBID)
+			cm.ReplyToLogin = metaid.MakeUserLoginID(msg.RepliedToMessage.SenderFBID)
+		}
 	}
 	switch content := msg.Content.Content.(type) {
 	case *slidetypes.MessageContentText:


### PR DESCRIPTION
Fix a panic when the `RepliedToMessage` is nil which apparently can happen.