### PR TITLE
bloks: implement i64.Convert, i32.Convert, f32.Convert

### DIFF
--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -924,6 +925,40 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		return BloksNothing, nil
 	case "bk.action.i64.Const":
 		return i.Evaluate(ctx, &call.Args[0])
+	case "bk.action.i64.Convert", "bk.action.i32.Convert":
+		// Both collapse to int64 here: this interpreter has no separate 32-bit integer
+		// representation (BloksScriptLiteralValue only ever holds int64 for whole numbers,
+		// see BloksScriptLiteral.Parse), so i32 vs i64 only mattered in Meta's original typed
+		// VM, not in this reimplementation.
+		val, err := i.Evaluate(ctx, &call.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		switch v := val.Value().(type) {
+		case int64:
+			return BloksLiteralOf(v), nil
+		case float64:
+			return BloksLiteralOf(int64(v)), nil
+		case string:
+			n, perr := strconv.ParseInt(v, 10, 64)
+			if perr != nil {
+				return nil, fmt.Errorf("%s: cannot convert %q to int: %w", call.Function, v, perr)
+			}
+			return BloksLiteralOf(n), nil
+		case bool:
+			if v {
+				return BloksLiteralOf(int64(1)), nil
+			}
+			return BloksLiteralOf(int64(0)), nil
+		default:
+			return nil, fmt.Errorf("%s: cannot convert %T to int", call.Function, val.Value())
+		}
+	case "bk.action.f32.Convert":
+		n, err := evalFloat(ctx, i, &call.Args[0], "f32.Convert")
+		if err != nil {
+			return nil, err
+		}
+		return BloksLiteralOf(n), nil
 	case "bk.action.map.Get":
 		obj, err := evalAs[map[string]*BloksScriptLiteral](ctx, i, &call.Args[0], "merge")
 		if err != nil {


### PR DESCRIPTION
## Summary

These three numeric-conversion opcodes exist in the Bloks bytecode format (they're present in
`minify.json`'s table: `i64.Convert` = `eue`, `i32.Convert` = `etz`, `f32.Convert` = `e54`), but
none had a case in `interp.go`'s dispatch switch, so any Bloks screen using one fails outright
with `unimplemented function bk.action.i64.Convert (1 args)`.

Hit in practice on a plain email+password `MessengerLite.DoLoginSteps` login — the login button's
Bloks action graph calls `i64.Convert`, so the login flow can't complete past that screen at all.

`i32`/`i64` both collapse to `int64` here since `BloksScriptLiteralValue` has no separate 32-bit
integer representation in this reimplementation (see `BloksScriptLiteral.Parse`, which only ever
produces `int64` for whole numbers) — the width distinction only mattered in Meta's original typed
VM. `f32.Convert` mirrors the existing `evalFloat` coercion (`float64` or `int64` in, `float64`
out) already used by `f32.Add` etc.

## Test plan

- [x] `go build ./pkg/messagix/bloks/...` / `go vet ./...` — clean
- [x] `gofmt -l` — clean
- [ ] Exercised in a real `DoLoginSteps` login that previously failed on this exact error; report
      follow-up in this PR once confirmed end-to-end on a real account

🤖 Generated with [Claude Code](https://claude.com/claude-code)