### PR TITLE
bloks: don't hard-fail AssertType on unknown (>7) type tags

### DIFF
--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -924,6 +925,40 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 		return BloksNothing, nil
 	case "bk.action.i64.Const":
 		return i.Evaluate(ctx, &call.Args[0])
+	case "bk.action.i64.Convert", "bk.action.i32.Convert":
+		// Both collapse to int64 here: this interpreter has no separate 32-bit integer
+		// representation (BloksScriptLiteralValue only ever holds int64 for whole numbers,
+		// see BloksScriptLiteral.Parse), so i32 vs i64 only mattered in Meta's original typed
+		// VM, not in this reimplementation.
+		val, err := i.Evaluate(ctx, &call.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		switch v := val.Value().(type) {
+		case int64:
+			return BloksLiteralOf(v), nil
+		case float64:
+			return BloksLiteralOf(int64(v)), nil
+		case string:
+			n, perr := strconv.ParseInt(v, 10, 64)
+			if perr != nil {
+				return nil, fmt.Errorf("%s: cannot convert %q to int: %w", call.Function, v, perr)
+			}
+			return BloksLiteralOf(n), nil
+		case bool:
+			if v {
+				return BloksLiteralOf(int64(1)), nil
+			}
+			return BloksLiteralOf(int64(0)), nil
+		default:
+			return nil, fmt.Errorf("%s: cannot convert %T to int", call.Function, val.Value())
+		}
+	case "bk.action.f32.Convert":
+		n, err := evalFloat(ctx, i, &call.Args[0], "f32.Convert")
+		if err != nil {
+			return nil, err
+		}
+		return BloksLiteralOf(n), nil
 	case "bk.action.map.Get":
 		obj, err := evalAs[map[string]*BloksScriptLiteral](ctx, i, &call.Args[0], "merge")
 		if err != nil {

--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 type CheckpointError struct {
@@ -996,7 +997,24 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 			return nil, err
 		}
 		if expected != actual {
-			return nil, fmt.Errorf("bloks type assertion failure (%d != %d)", actual, expected)
+			// getBloksType only ever returns the small set of primitive kind tags this
+			// reimplementation knows about (see its switch: 0/1/2/3/4/6/7, plus 5 and 8 as
+			// documented-but-unmapped placeholders). An `expected` far outside that range (seen
+			// in practice: 100, mid-login) is not a primitive kind at all -- it's almost
+			// certainly one of Meta's richer named/semantic Bloks types (e.g. a distinctly
+			// tagged "ID" or "Timestamp" scalar) that this interpreter has no schema for, not a
+			// real type mismatch on our part. Failing the whole login on an assertion we can't
+			// actually evaluate is worse than letting it through: log it so a real mismatch
+			// (both tags inside the known range, genuinely different) still fails loudly, the
+			// same as before.
+			if expected < 0 || expected > 7 {
+				zerolog.Ctx(ctx).Warn().
+					Int64("actual_type", actual).
+					Int64("expected_type", expected).
+					Msg("bloks AssertType: expected type is outside the known primitive range, passing through unchecked")
+			} else {
+				return nil, fmt.Errorf("bloks type assertion failure (%d != %d)", actual, expected)
+			}
 		}
 		return val, nil
 	case "bk.action.mins.TypeOf":


### PR DESCRIPTION
## Summary

Separate from #317 on purpose — that one's a clean opcode implementation; this one is a
judgment call I want reviewed independently.

`getBloksType` only ever produces the small set of primitive kind tags this reimplementation
knows about (0/1/2/3/4/6/7, plus 5 and 8 as documented-but-unmapped placeholders per its own
"TBD" comment). Hit in practice mid-login (`MessengerLite.DoLoginSteps`, right after submitting
credentials): `AssertType` asserted expected type `100` against an actual `int64` (`3`) —
`bloks type assertion failure (3 != 100)`. `100` isn't anywhere near the known primitive range,
so this reads as one of Meta's richer named/semantic Bloks types (a distinctly tagged "ID" or
"Timestamp" scalar, say) that this interpreter has no schema for, not a genuine type error on
our part.

**This is a best-effort mitigation, not a confirmed root-cause fix** — I don't have real captured
traffic or Meta's actual type schema to know what tag `100` (or any other `>7` tag) really means.
But hard-failing the entire login on an assertion this interpreter structurally can't evaluate
seemed worse than logging a warning and letting the value through. A real mismatch between two
tags *both* inside the known range still fails loudly, exactly as before — only the
"expected tag is outside what `getBloksType` can ever produce" case is now non-fatal.

Happy to close this in favor of a more precise fix if someone with real traffic/schema knowledge
has one — flagging the uncertainty explicitly rather than presenting this as settled.

## Test plan

- [x] `go build ./pkg/messagix/bloks/...` / `go vet ./...` — clean
- [x] `gofmt -l` — clean
- [ ] Login proceeded past this point on a real account after applying the patch; will report back
      here once confirmed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)