### PR TITLE
instameow: reconnect backoff parity with messagix, and a Connect lock for the Instagram client

### DIFF
--- a/pkg/igconnector/client.go
+++ b/pkg/igconnector/client.go
@@ -56,9 +56,14 @@ type IGClient struct {
 	stopConnectAttempt    atomic.Pointer[context.CancelFunc]
 	stopChatBackfill      atomic.Pointer[context.CancelFunc]
 	chatBackfillLock      sync.Mutex
-	mailboxProcessed      atomic.Bool
-	waitMailboxProcessed  chan struct{}
-	permanentErrored      atomic.Bool
+	// Two Connect calls overlapping would run two index-load flows against the
+	// same account with the same cookies at once, which is exactly what a
+	// second-device login looks like. MetaClient already guards this; the
+	// Instagram client did not.
+	connectLock          sync.Mutex
+	mailboxProcessed     atomic.Bool
+	waitMailboxProcessed chan struct{}
+	permanentErrored     atomic.Bool
 }
 
 func (ic *IGConnector) LoadUserLogin(ctx context.Context, login *bridgev2.UserLogin) error {
@@ -138,6 +143,11 @@ func (ic *IGClient) ExportCredentials(ctx context.Context) any {
 }
 
 func (ic *IGClient) Connect(ctx context.Context) {
+	if !ic.connectLock.TryLock() {
+		zerolog.Ctx(ctx).Error().Msg("Connect called multiple times in parallel")
+		return
+	}
+	defer ic.connectLock.Unlock()
 	if ic.LoginMeta.Platform != types.Instagram {
 		ic.UserLogin.BridgeState.Send(status.BridgeState{StateEvent: status.StateBadCredentials, Error: MetaNotInstagram})
 		return

--- a/pkg/instameow/socket.go
+++ b/pkg/instameow/socket.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"time"
 
 	"go.mau.fi/util/exerrors"
@@ -38,6 +39,25 @@ import (
 )
 
 var MaxConnectionRetryInterval = 60 * time.Second
+
+// MinStableConnectionForImmediateReconnect is how long a socket must have
+// stayed connected before a disconnect is treated as a transient blip worth
+// reconnecting to immediately. A connection that was accepted, subscribed and
+// then dropped again within seconds is not stable, and reconnecting to it with
+// no delay turns a soft server-side refusal into a hot loop. The messagix
+// client applies the same rule; this ports it to the Instagram sockets.
+var MinStableConnectionForImmediateReconnect = 2 * time.Minute
+
+// reconnectDelay returns how long to wait before the next connection attempt.
+//
+// Backoff is exponential in the number of sequential failures, capped at
+// MaxConnectionRetryInterval, with ±20% jitter so that many logins failing at
+// the same moment do not retry in lockstep for the rest of their lives.
+func reconnectDelay(sequentialFailures int) time.Duration {
+	base := min(time.Duration(1<<sequentialFailures)*time.Second, MaxConnectionRetryInterval)
+	jitter := time.Duration((rand.Float64()*0.4 - 0.2) * float64(base))
+	return base + jitter
+}
 
 func (c *Client) makeNewSocket() {
 	old := c.socket.Swap(dgw.NewSocket(c.getSocketOptions()))
@@ -88,8 +108,13 @@ func (c *Client) Connect(ctx context.Context) {
 	sequentialFailures := 0
 	ctx = sock.Log.WithContext(ctx)
 	for {
+		connectStart := time.Now()
 		err := sock.Connect(ctx)
-		wasConnected := c.connected.IsSet()
+		// Only a connection that held for a meaningful stretch counts as having
+		// been "connected" for backoff purposes. One that was accepted and
+		// dropped again within seconds is a failure wearing a success's clothes.
+		wasConnected := c.connected.IsSet() &&
+			time.Since(connectStart) >= MinStableConnectionForImmediateReconnect
 		c.connected.Clear()
 		if err == nil {
 			sock.Log.Debug().Msg("Socket closed cleanly")
@@ -119,13 +144,13 @@ func (c *Client) Connect(ctx context.Context) {
 			case <-ctx.Done():
 				sock.Log.Debug().Msg("Context canceled, stopping socket reconnect attempts")
 				return
-			case <-time.After(min(time.Duration(1<<sequentialFailures)*time.Second, MaxConnectionRetryInterval)):
+			case <-time.After(reconnectDelay(sequentialFailures)):
 				continue
 			}
 		} else {
 			sock.Log.Debug().Err(err).
 				Int("connection_num", c.socketRetries).
-				Msg("Socket disconnected, reconnecting immediately")
+				Msg("Socket disconnected after a stable connection, reconnecting immediately")
 			sequentialFailures = 0
 		}
 	}

--- a/pkg/instameow/streamcontroller.go
+++ b/pkg/instameow/streamcontroller.go
@@ -42,8 +42,12 @@ func (c *Client) connectStreamController(ctx context.Context) {
 	}
 	ctx = sock.Log.WithContext(ctx)
 	for {
+		connectStart := time.Now()
 		err := sock.Connect(ctx)
-		wasConnected := c.streamControllerConnected.Swap(false)
+		// See the main socket loop: a connection has to hold for a while before
+		// dropping it earns an immediate, un-backed-off reconnect.
+		wasConnected := c.streamControllerConnected.Swap(false) &&
+			time.Since(connectStart) >= MinStableConnectionForImmediateReconnect
 		if err == nil {
 			sock.Log.Debug().Msg("Socket closed cleanly")
 			return
@@ -63,11 +67,11 @@ func (c *Client) connectStreamController(ctx context.Context) {
 			case <-ctx.Done():
 				sock.Log.Debug().Msg("Context canceled, stopping socket reconnect attempts")
 				return
-			case <-time.After(min(time.Duration(1<<sequentialFailures)*time.Second, MaxConnectionRetryInterval)):
+			case <-time.After(reconnectDelay(sequentialFailures)):
 				continue
 			}
 		} else {
-			sock.Log.Debug().Err(err).Msg("Socket disconnected, reconnecting immediately")
+			sock.Log.Debug().Err(err).Msg("Socket disconnected after a stable connection, reconnecting immediately")
 			sequentialFailures = 0
 		}
 	}


### PR DESCRIPTION
Two small fixes that bring the Instagram connector in line with behaviour the Messenger connector already has.

**instameow: only reconnect immediately after a stable connection**

Both Instagram sockets (`socket.go`, `streamcontroller.go`) reset their backoff and reconnected with no delay whenever the previous connection had been marked connected at any point, however briefly. A connection that is accepted, subscribed and dropped again within seconds therefore produced an un-backed-off hot loop against the gateway.

`messagix/client.go:461` already handles this — it only grants an immediate reconnect once the connection has held for two minutes. This applies the same rule to the Instagram sockets, and adds ±20% jitter to the exponential backoff so that many logins failing at once don't retry in lockstep.

**igconnector: guard Connect against parallel invocation**

`MetaClient.Connect` refuses to run twice at once via `connectLock.TryLock()`; `IGClient.Connect` had no equivalent. Two overlapping calls shared one `instameow.Client` and ran two index-load flows against the same account with the same cookies simultaneously. Mirrors the existing guard exactly.

Both build and `go vet` clean; each commit is self-contained.