### PR TITLE
Honour Retry-After on 429; cap and jitter the connect retry backoff

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -200,7 +200,7 @@ func (m *MetaClient) connectWithRetry(retryCtx, ctx context.Context, attempts in
 		return
 	}
 	if attempts > 0 {
-		retryIn := time.Duration(1<<attempts) * time.Second
+		retryIn := metaid.ConnectRetryDelay(attempts)
 		zerolog.Ctx(ctx).Debug().Stringer("retry_in", retryIn).Msg("Sleeping before retrying connection")
 		select {
 		case <-time.After(retryIn):

--- a/pkg/messagix/httpclient/http.go
+++ b/pkg/messagix/httpclient/http.go
@@ -426,6 +426,12 @@ func (c *HTTPClient) makeRequest(
 		backoff := time.Duration(attempts) * 3 * time.Second
 		if resp != nil && resp.StatusCode == 429 {
 			backoff *= 2
+			// When the server says how long to wait, that is the floor. Retrying
+			// on our own shorter schedule through a rate limit is how a throttle
+			// turns into a block.
+			if retryAfter := parseRetryAfter(resp.Header.Get("Retry-After")); retryAfter > backoff {
+				backoff = retryAfter
+			}
 		}
 		logContext(c.log.Err(err)).
 			Str("url", url).
@@ -439,6 +445,25 @@ func (c *HTTPClient) makeRequest(
 			return resp, nil, ctx.Err()
 		}
 	}
+}
+
+// parseRetryAfter reads a Retry-After header as either delta-seconds or an
+// HTTP-date, per RFC 9110 §10.2.3. Anything unparsable is treated as absent so
+// a malformed header can never make things worse than no header at all.
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if at, err := http.ParseTime(value); err == nil {
+		if until := time.Until(at); until > 0 {
+			return until
+		}
+	}
+	return 0
 }
 
 func (c *HTTPClient) makeRequestDirect(ctx context.Context, url string, method string, headers http.Header, payload []byte, contentType types.ContentType) (*http.Response, []byte, error) {

--- a/pkg/messagix/httpclient/retryafter_test.go
+++ b/pkg/messagix/httpclient/retryafter_test.go
@@ -1,0 +1,36 @@
+package httpclient
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"garbage", 0},
+		{"-5", 0},
+		{"0", 0},
+		{"30", 30 * time.Second},
+		{" 7 ", 7 * time.Second},
+	}
+	for _, c := range cases {
+		if got := parseRetryAfter(c.in); got != c.want {
+			t.Errorf("parseRetryAfter(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+	// An HTTP-date in the future parses to roughly that far ahead.
+	future := time.Now().Add(90 * time.Second).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfter(future); got < 85*time.Second || got > 91*time.Second {
+		t.Errorf("HTTP-date parse gave %v, want ~90s", got)
+	}
+	// An HTTP-date in the past is treated as absent, never negative.
+	past := time.Now().Add(-90 * time.Second).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfter(past); got != 0 {
+		t.Errorf("past HTTP-date gave %v, want 0", got)
+	}
+}

--- a/pkg/metaid/backoff.go
+++ b/pkg/metaid/backoff.go
@@ -1,0 +1,31 @@
+package metaid
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// MaxConnectRetryInterval caps how long a connect retry will ever wait. Without
+// a cap, 1<<attempts seconds outgrows any sane number within a couple of dozen
+// failures.
+var MaxConnectRetryInterval = 5 * time.Minute
+
+// ConnectRetryDelay returns how long to sleep before the next connection
+// attempt: exponential in the attempt count, capped, with ±20% jitter.
+//
+// The jitter is the part that matters for a bridge serving many logins. Every
+// login that fails at the same moment — a shared network blip, a process
+// restart — would otherwise retry in perfect lockstep at 2s, 4s, 8s ... for the
+// rest of its life, which is both a thundering herd against the remote service
+// and indistinguishable from coordinated automated traffic.
+func ConnectRetryDelay(attempts int) time.Duration {
+	if attempts < 0 {
+		attempts = 0
+	}
+	if attempts > 30 {
+		attempts = 30
+	}
+	base := min(time.Duration(1<<attempts)*time.Second, MaxConnectRetryInterval)
+	jitter := time.Duration((rand.Float64()*0.4 - 0.2) * float64(base))
+	return base + jitter
+}

--- a/pkg/metaid/backoff_test.go
+++ b/pkg/metaid/backoff_test.go
@@ -1,0 +1,35 @@
+package metaid
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConnectRetryDelayStaysWithinJitterBand(t *testing.T) {
+	for attempts := 0; attempts < 40; attempts++ {
+		for i := 0; i < 200; i++ {
+			d := ConnectRetryDelay(attempts)
+			base := min(time.Duration(1<<min(attempts, 30))*time.Second, MaxConnectRetryInterval)
+			lo, hi := time.Duration(float64(base)*0.8), time.Duration(float64(base)*1.2)
+			if d < lo || d > hi {
+				t.Fatalf("attempts=%d: delay %v outside [%v, %v]", attempts, d, lo, hi)
+			}
+		}
+	}
+}
+
+func TestConnectRetryDelayIsCapped(t *testing.T) {
+	if d := ConnectRetryDelay(60); d > time.Duration(float64(MaxConnectRetryInterval)*1.2) {
+		t.Fatalf("attempts=60 not capped: %v", d)
+	}
+}
+
+func TestConnectRetryDelayActuallyJitters(t *testing.T) {
+	seen := map[time.Duration]bool{}
+	for i := 0; i < 50; i++ {
+		seen[ConnectRetryDelay(5)] = true
+	}
+	if len(seen) < 10 {
+		t.Fatalf("expected varied delays, got %d distinct values", len(seen))
+	}
+}


### PR DESCRIPTION
**httpclient: honour Retry-After on 429**

A 429 was retried on a fixed local schedule (6s, 12s, 18s …) and the `Retry-After` header was never read, so when the server asked for a longer cooldown the client kept probing on its own shorter one. This uses the header — delta-seconds or HTTP-date — as the floor for the backoff. Unparsable values are treated as absent, so a bad header can't make things worse than no header. Test included.

**connector, igconnector: cap and jitter the connect retry backoff**

Both `connectWithRetry` loops slept `1<<attempts` seconds with no cap and no jitter. Uncapped, that outgrows any sane wait within a couple of dozen failures; unjittered, every login that fails at the same moment retries in perfect lockstep thereafter. One shared helper in `metaid` does both (5 min cap, ±20% jitter). Test included.

Independent of #320. Both build and test clean; each commit self-contained.