### PR TITLE
push: fix reload-page recovery when registering pusher

### DIFF
--- a/pkg/connector/push.go
+++ b/pkg/connector/push.go
@@ -98,7 +98,9 @@ func (m *MetaClient) RegisterPushNotifications(ctx context.Context, pushType bri
 	if errors.Is(err, types.ErrPleaseReloadPage) && m.canReconnect() {
 		zerolog.Ctx(ctx).Debug().Msg("Doing full reconnect and retrying push registration")
 		m.FullReconnect()
-		err = cli.Facebook.RegisterPushNotifications(ctx, token, keys)
+		if cli = m.Client; cli != nil {
+			err = cli.Facebook.RegisterPushNotifications(ctx, token, keys)
+		}
 	}
 	return err
 }

--- a/pkg/messagix/facebook.go
+++ b/pkg/messagix/facebook.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/google/go-querystring/query"
 	"go.mau.fi/util/jsonbytes"
@@ -65,6 +66,9 @@ func (fb *FacebookMethods) RegisterPushNotifications(ctx context.Context, endpoi
 
 	if !r.Payload.Success {
 		c.Logger.Err(err).Bytes("body", body).Msg("non-success push registration response")
+		if respErr := r.AsError(); respErr != nil {
+			return fmt.Errorf("non-success push registration response: %w", respErr)
+		}
 		return errors.New("non-success response payload")
 	}
 
@@ -72,6 +76,8 @@ func (fb *FacebookMethods) RegisterPushNotifications(ctx context.Context, endpoi
 }
 
 type pushNotificationsResponse struct {
+	types.ErrorResponse
+
 	Ar      int `json:"__ar"`
 	Payload struct {
 		Success bool `json:"success"`


### PR DESCRIPTION
Pass back proper resp err if valid from push registration (seen in the wild the "page needs reload" error).