### PR TITLE
connector: retry after consent required error

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -287,6 +287,7 @@ func (m *MetaClient) connectWithRetry(retryCtx, ctx context.Context, attempts in
 				Error:      FBConsentRequired,
 				UserAction: status.UserActionRestart,
 			})
+			go m.periodicReconnect()
 		} else if lsErr := (&types.ErrorResponse{}); errors.As(err, &lsErr) {
 			stateEvt := status.StateUnknownError
 			if lsErr.ErrorCode == 1357053 {


### PR DESCRIPTION
I have observed multiple occurrences of this where bridges land in this consent required error but reconnecting/reloading the page fixes it.

I guess this is fine because it'll just fall back into another bad creds if the user is indeed blocked, but feels like there's something else going on here 🤔 