### PR TITLE
messagix/bloks/cmd: rewrite

### DIFF
--- a/pkg/messagix/bloks/cmd_new/main.go
+++ b/pkg/messagix/bloks/cmd_new/main.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+
+	"github.com/rs/zerolog"
+
+	"go.mau.fi/mautrix-meta/pkg/messagix/bloks"
+	"go.mau.fi/mautrix-meta/pkg/messagix/types"
+)
+
+// Tool configuration
+var flagLogLevel = flag.String("log-level", "debug", "How much zerolog logging")
+
+// Client configuration
+var flagIsAndroid = flag.Bool("android", false, "Use Android client instead of iOS")
+
+// Main data inputs
+var flagUserInput = flag.String("user-input", "", "Login step user input key/value json")
+var flagReplayLog = flag.String("replay", "", "Log file to replay Bloks responses from")
+
+func main() {
+	err := mainE()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %s\n", err.Error())
+		os.Exit(1)
+	}
+}
+
+func readFile(filename string) ([]byte, error) {
+	if filename == "-" {
+		filename = "/dev/stdin"
+	}
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(file)
+}
+
+var logsRespGzRegexp = regexp.MustCompile(`"resp_gz":"([^"]+)"`)
+var logsBloksAppRegexp = regexp.MustCompile(`"bloks_app":"([^"]+)"`)
+
+func readReplayLogFile(filename string) (map[string][][]byte, error) {
+	contents, err := readFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	history := map[string][][]byte{}
+	for _, line := range bytes.Split(contents, []byte("\n")) {
+		bloksAppMatch := logsBloksAppRegexp.FindSubmatch(line)
+		respGzMatch := logsRespGzRegexp.FindSubmatch(line)
+		if bloksAppMatch == nil || respGzMatch == nil {
+			continue
+		}
+		bloksApp := string(bloksAppMatch[1])
+		respGzBase64 := respGzMatch[1]
+		respGz, err := base64.StdEncoding.AppendDecode(nil, respGzBase64)
+		if err != nil {
+			return nil, err
+		}
+		gzipReader, err := gzip.NewReader(bytes.NewReader(respGz))
+		if err != nil {
+			return nil, err
+		}
+		resp, err := io.ReadAll(gzipReader)
+		if err != nil {
+			return nil, err
+		}
+		history[bloksApp] = append(history[bloksApp], resp)
+	}
+	return history, nil
+}
+
+func mainE() error {
+	flag.Parse()
+
+	ctx := context.Background()
+	logLevel, err := zerolog.ParseLevel(*flagLogLevel)
+	if err != nil {
+		return err
+	}
+	log := zerolog.New(zerolog.NewConsoleWriter()).Level(logLevel)
+	ctx = log.WithContext(ctx)
+
+	plat := types.MessengerLiteIOS
+	if *flagIsAndroid {
+		plat = types.MessengerLiteAndroid
+	}
+
+	userInput := map[string]string{}
+	if *flagUserInput != "" {
+		err = json.Unmarshal([]byte(*flagUserInput), &userInput)
+		if err != nil {
+			return err
+		}
+	}
+
+	replayLog := map[string][][]byte{}
+	if *flagReplayLog != "" {
+		replayLog, err = readReplayLogFile(*flagReplayLog)
+		if err != nil {
+			return err
+		}
+	}
+
+	b, err := bloks.NewBrowser(&bloks.BrowserConfig{
+		Platform: plat,
+		EncryptPassword: func(ctx context.Context, password string) (string, error) {
+			return fmt.Sprintf(`#PWD_TEST_UNENCRYPTED:` + password), nil
+		},
+		MakeBloksRequest: func(ctx context.Context, doc *bloks.BloksDoc, appID string, inner bloks.BloksParamsInner, deviceID string, familyDeviceID string) (*bloks.BloksBundle, error) {
+			log.Debug().Str("bloks_app", appID).Msg("Making Bloks request")
+			if prepared := replayLog[appID]; prepared != nil {
+				replayLog[appID] = prepared[1:]
+				var respInner bloks.BloksBundle
+				err := json.Unmarshal(prepared[0], &respInner)
+				if err != nil {
+					return nil, err
+				}
+				return &respInner, nil
+			}
+			return nil, fmt.Errorf("missing bloks response: %s", appID)
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	availableUserInput := map[string]string{}
+	for b.State != bloks.StateSuccess {
+		step, err := b.DoLoginStep(ctx, availableUserInput)
+		if err != nil {
+			return err
+		}
+		if step != nil && step.UserInputParams != nil {
+			for _, input := range step.UserInputParams.Fields {
+				if provided := userInput[input.ID]; provided != "" {
+					availableUserInput[input.ID] = provided
+				} else {
+					return fmt.Errorf("missing user input: %s", input.ID)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/messagix/bloks/cmd_new/main.go
+++ b/pkg/messagix/bloks/cmd_new/main.go
@@ -117,7 +117,7 @@ func mainE() error {
 	b, err := bloks.NewBrowser(&bloks.BrowserConfig{
 		Platform: plat,
 		EncryptPassword: func(ctx context.Context, password string) (string, error) {
-			return fmt.Sprintf(`#PWD_TEST_UNENCRYPTED:` + password), nil
+			return fmt.Sprintf(`#PWD_TEST_UNENCRYPTED:%s`, password), nil
 		},
 		MakeBloksRequest: func(ctx context.Context, doc *bloks.BloksDoc, appID string, inner bloks.BloksParamsInner, deviceID string, familyDeviceID string) (*bloks.BloksBundle, error) {
 			log.Debug().Str("bloks_app", appID).Msg("Making Bloks request")

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -2219,15 +2219,20 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 	if b.State == prevState {
 		if step != nil {
 			fieldIDs := []string{}
+			fieldOptions := []string{}
 			if step.UserInputParams != nil {
 				for _, field := range step.UserInputParams.Fields {
 					fieldIDs = append(fieldIDs, field.ID)
+					if field.Type == bridgev2.LoginInputFieldTypeSelect {
+						fieldOptions = append(fieldOptions, field.Options...)
+					}
 				}
 			}
 			log.Debug().
 				Str("cur_state", string(b.State)).
 				Str("step_id", step.StepID).
 				Strs("field_ids", fieldIDs).
+				Strs("field_options", fieldOptions).
 				Msg("Requested user input")
 		} else if b.LastError != "" {
 			log.Debug().


### PR DESCRIPTION
It calls the actual bridge code now, instead of running a separate copy of all of the logic that isn't guaranteed to actually be kept up to date as the real code.

It gains the ability to parse a raw log file and replay the embedded responses whenever the bridge code wants to make a request.

Some of the features from the old implementation aren't fully present in the new version, so I'm leaving the old version around for the moment. However, it should be straightforward to patch any issues, after which we should get rid of the old one.
