### PR TITLE
Assorted correctness fixes

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -511,7 +511,7 @@ func (m *MetaClient) saveConnectionState(ctx context.Context, state json.RawMess
 	}
 	m.lastStateSaveLock.Unlock()
 	if state == nil {
-		if !ratelimited {
+		if ratelimited {
 			return
 		}
 		state, _ = m.Client.DumpState()

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -130,7 +130,11 @@ func (m *MetaConnector) getProxy(reason string) (string, error) {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)
-	} else if resp.StatusCode >= 300 || resp.StatusCode < 200 {
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
 		return "", fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 	var respData respGetProxy

--- a/pkg/connector/handlemeta.go
+++ b/pkg/connector/handlemeta.go
@@ -143,6 +143,7 @@ func (m *MetaClient) parseAndQueueTable(ctx context.Context, tbl *table.LSTable,
 	}
 	if ctx.Err() != nil {
 		zerolog.Ctx(ctx).Warn().Err(ctx.Err()).Msg("Not dispatching parsed table, context is canceled")
+		return
 	}
 	select {
 	case m.parsedTables <- wrapped:

--- a/pkg/connector/userinfo.go
+++ b/pkg/connector/userinfo.go
@@ -46,8 +46,21 @@ const (
 	MetaAIMessengerID = 156025504001094
 )
 
+// makeUserIdentifiers returns the identifier list for a Facebook user, in the same
+// `network:handle` form the Instagram connector uses. Vanity usernames are optional
+// on Facebook, so fall back to the numeric ID, which works in profile URLs too.
+func makeUserIdentifiers(info types.UserInfo) []string {
+	if username := info.GetUsername(); username != "" {
+		return []string{fmt.Sprintf("facebook:%s", username)}
+	} else if fbid := info.GetFBID(); fbid != 0 {
+		return []string{fmt.Sprintf("facebook:%d", fbid)}
+	}
+	return nil
+}
+
 func (m *MetaClient) wrapUserInfo(info types.UserInfo) *bridgev2.UserInfo {
 	return &bridgev2.UserInfo{
+		Identifiers: makeUserIdentifiers(info),
 		Name: ptr.Ptr(m.Main.Config.FormatDisplayname(DisplaynameParams{
 			DisplayName: info.GetName(),
 			Username:    info.GetUsername(),

--- a/pkg/igconnector/chatsync.go
+++ b/pkg/igconnector/chatsync.go
@@ -130,7 +130,9 @@ func (ic *IGClient) doChatBackfill(ctx context.Context, startCursor string) {
 	}
 
 	batchCount := 0
-	if startCursor == "" {
+	cursor := startCursor
+	hasNextPage := true
+	if cursor == "" {
 		log.Info().Msg("No start cursor, loading from scratch")
 		resp, err := ic.Client.GetMailbox(ctx)
 		if err != nil {
@@ -140,16 +142,18 @@ func (ic *IGClient) doChatBackfill(ctx context.Context, startCursor string) {
 		if !processThreads(resp.Mailbox.ThreadsByFolder) {
 			return
 		}
+		cursor = resp.Mailbox.ThreadsByFolder.PageInfo.EndCursor
+		hasNextPage = resp.Mailbox.ThreadsByFolder.PageInfo.HasNextPage
 	} else {
 		batchCount++
 	}
-	for batchCount < ic.Main.Config.ThreadBackfill.BatchCount {
+	for hasNextPage && cursor != "" && batchCount < ic.Main.Config.ThreadBackfill.BatchCount {
 		select {
 		case <-time.After(ic.Main.Config.ThreadBackfill.BatchDelay):
 		case <-ctx.Done():
 			return
 		}
-		resp, err := ic.Client.PaginateMailbox(ctx, slidetypes.MakePaginateMailboxRequest(viewerFBID, startCursor, "INBOX", nil))
+		resp, err := ic.Client.PaginateMailbox(ctx, slidetypes.MakePaginateMailboxRequest(viewerFBID, cursor, "INBOX", nil))
 		if err != nil {
 			log.Err(err).Msg("Failed to fetch more chats")
 			return
@@ -158,9 +162,8 @@ func (ic *IGClient) doChatBackfill(ctx context.Context, startCursor string) {
 			return
 		}
 		batchCount++
-		if !resp.Mailbox.ThreadsByFolder.PageInfo.HasNextPage {
-			break
-		}
+		cursor = resp.Mailbox.ThreadsByFolder.PageInfo.EndCursor
+		hasNextPage = resp.Mailbox.ThreadsByFolder.PageInfo.HasNextPage
 	}
 	log.Info().Int("total_batch_count", batchCount).Msg("Completed chat backfill successfully")
 	ic.LoginMeta.BackfillCompleted = true

--- a/pkg/igconnector/chatsync.go
+++ b/pkg/igconnector/chatsync.go
@@ -138,6 +138,9 @@ func (ic *IGClient) doChatBackfill(ctx context.Context, startCursor string) {
 		if err != nil {
 			log.Err(err).Msg("Failed to fetch initial inbox")
 			return
+		} else if resp.Mailbox == nil {
+			log.Warn().Msg("Initial inbox response didn't contain a mailbox")
+			return
 		}
 		if !processThreads(resp.Mailbox.ThreadsByFolder) {
 			return
@@ -156,6 +159,9 @@ func (ic *IGClient) doChatBackfill(ctx context.Context, startCursor string) {
 		resp, err := ic.Client.PaginateMailbox(ctx, slidetypes.MakePaginateMailboxRequest(viewerFBID, cursor, "INBOX", nil))
 		if err != nil {
 			log.Err(err).Msg("Failed to fetch more chats")
+			return
+		} else if resp.Mailbox == nil {
+			log.Warn().Msg("Pagination response didn't contain a mailbox")
 			return
 		}
 		if !processThreads(resp.Mailbox.ThreadsByFolder) {

--- a/pkg/igconnector/client.go
+++ b/pkg/igconnector/client.go
@@ -106,7 +106,11 @@ func (ic *IGConnector) getProxy(reason string) (string, error) {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)
-	} else if resp.StatusCode >= 300 || resp.StatusCode < 200 {
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
 		return "", fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 	var respData respGetProxy

--- a/pkg/instameow/client.go
+++ b/pkg/instameow/client.go
@@ -212,6 +212,8 @@ func (c *Client) LoadIndex(ctx context.Context) (*types.PolarisViewer, *slidetyp
 	mailbox, err := c.GetMailbox(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get mailbox: %w", err)
+	} else if mailbox.GetMailbox() == nil {
+		return nil, nil, ErrMailboxMissing
 	}
 	c.seqID = mailbox.Mailbox.UQSeqID
 	c.seqIDTS = time.Now()
@@ -271,6 +273,7 @@ const MaxCachedStateAge = 24 * time.Hour
 
 var ErrCachedStateTooOld = errors.New("cached state is too old")
 var ErrClientIsNil = errors.New("client is nil")
+var ErrMailboxMissing = errors.New("mailbox missing from response")
 
 func (c *Client) LoadState(state json.RawMessage) error {
 	if c == nil {

--- a/pkg/instameow/login_account_manager.go
+++ b/pkg/instameow/login_account_manager.go
@@ -266,7 +266,7 @@ func (c *Client) switchInstagramAccountManagerProfile(
 		return fmt.Errorf("failed to prepare the primary Instagram web session: %w", err)
 	}
 	primaryCookies := c.cookies.GetAll()
-	primaryWWWClaim := c.cookies.IGWWWClaim
+	primaryWWWClaim := c.cookies.GetWWWClaim()
 
 	if err := c.switchInstagramAccountManagerMobileAccount(ctx, state, account); err != nil {
 		return err
@@ -276,7 +276,7 @@ func (c *Client) switchInstagramAccountManagerProfile(
 	// provisioned separately. Switch the already authenticated primary web session
 	// through Instagram's matching FXCAL endpoint before persisting the selection.
 	c.cookies.UpdateValues(primaryCookies)
-	c.cookies.IGWWWClaim = primaryWWWClaim
+	c.cookies.SetWWWClaim(primaryWWWClaim)
 	if err := c.switchInstagramAccountManagerWebAccount(ctx, account.Username); err != nil {
 		return err
 	}

--- a/pkg/instameow/login_web.go
+++ b/pkg/instameow/login_web.go
@@ -159,10 +159,10 @@ func (c *Client) addInstagramWebLoginHeaders(headers http.Header) error {
 	}
 	headers.Set("x-instagram-ajax", config.InstagramWebPushInfo.RolloutHash)
 	headers.Set("x-web-session-id", c.configs.WebSessionID)
-	if c.cookies.IGWWWClaim == "" {
+	if wwwClaim := c.cookies.GetWWWClaim(); wwwClaim == "" {
 		headers.Set("x-ig-www-claim", "0")
 	} else {
-		headers.Set("x-ig-www-claim", c.cookies.IGWWWClaim)
+		headers.Set("x-ig-www-claim", wwwClaim)
 	}
 	if config.PolarisSiteData.SendDeviceIDHeader {
 		if config.PolarisSiteData.DeviceID == "" {
@@ -329,7 +329,7 @@ func (c *Client) CreateInstagramWebSession(
 		cookies.IGCookieMachineID: c.cookies.Get(cookies.IGCookieMachineID),
 		cookies.IGCookieDeviceID:  c.cookies.Get(cookies.IGCookieDeviceID),
 	})
-	c.cookies.IGWWWClaim = ""
+	c.cookies.SetWWWClaim("")
 
 	c.configs = httpclient.NewConfigs(c)
 	c.http.SetConfigs(c.configs)

--- a/pkg/messagix/cookies/cookies.go
+++ b/pkg/messagix/cookies/cookies.go
@@ -54,7 +54,7 @@ type Cookies struct {
 	values   map[MetaCookieName]string
 	lock     sync.RWMutex
 
-	IGWWWClaim string
+	igWWWClaim string
 }
 
 func (c *Cookies) UpdateValues(newValues map[MetaCookieName]string) {
@@ -67,10 +67,14 @@ func (c *Cookies) UpdateValues(newValues map[MetaCookieName]string) {
 }
 
 func (c *Cookies) MarshalJSON() ([]byte, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return json.Marshal(c.values)
 }
 
 func (c *Cookies) UnmarshalJSON(data []byte) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return json.Unmarshal(data, &c.values)
 }
 
@@ -158,6 +162,21 @@ func (c *Cookies) Set(key MetaCookieName, value string) {
 	c.values[key] = value
 }
 
+func (c *Cookies) GetWWWClaim() string {
+	if c == nil {
+		return ""
+	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.igWWWClaim
+}
+
+func (c *Cookies) SetWWWClaim(claim string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.igWWWClaim = claim
+}
+
 func (c *Cookies) UpdateFromResponse(r *http.Response) {
 	if c == nil || r == nil {
 		return
@@ -181,7 +200,7 @@ func (c *Cookies) UpdateFromResponse(r *http.Response) {
 		}
 	}
 	if wwwClaim := r.Header.Get("x-ig-set-www-claim"); wwwClaim != "" {
-		c.IGWWWClaim = wwwClaim
+		c.igWWWClaim = wwwClaim
 	}
 }
 

--- a/pkg/messagix/cookies/cookies_test.go
+++ b/pkg/messagix/cookies/cookies_test.go
@@ -1,0 +1,70 @@
+package cookies
+
+import (
+	"encoding/json"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+const concurrencyIterations = 500
+
+// Cookies is stored in the user login metadata, so it gets marshaled from
+// whichever goroutine calls UserLogin.Save while HTTP responses keep updating
+// it. Run both at once to make sure the map is never touched without the lock.
+func TestCookiesConcurrentMarshalAndUpdate(t *testing.T) {
+	c := &Cookies{}
+	c.UpdateValues(map[MetaCookieName]string{IGCookieSessionID: "session"})
+
+	errs := make(chan error, concurrencyIterations)
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := range concurrencyIterations {
+			c.Set(IGCookieRUR, strconv.Itoa(i))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range concurrencyIterations {
+			if _, err := json.Marshal(c); err != nil {
+				errs <- err
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range concurrencyIterations {
+			if err := json.Unmarshal([]byte(`{"sessionid":"other"}`), c); err != nil {
+				errs <- err
+			}
+		}
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestCookiesConcurrentWWWClaim(t *testing.T) {
+	c := &Cookies{}
+	c.UpdateValues(nil)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range concurrencyIterations {
+			c.SetWWWClaim(strconv.Itoa(i))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range concurrencyIterations {
+			c.GetWWWClaim()
+		}
+	}()
+	wg.Wait()
+}

--- a/pkg/messagix/httpclient/graphql.go
+++ b/pkg/messagix/httpclient/graphql.go
@@ -253,7 +253,7 @@ func (c *HTTPClient) MakeGraphQLRequest(ctx context.Context, name string, variab
 
 	reqUrl := c.parent.GetEndpoint("graphql")
 	//c.Logger.Info().Any("url", reqUrl).Any("payload", string(payloadBytes)).Any("headers", headers).Msg("Sending graphQL request.")
-	resp, respData, err := c.makeRequest(ctx, reqUrl, "POST", headers, payloadBytes, types.FORM, func(e *zerolog.Event) *zerolog.Event {
+	resp, respData, err := c.makeRequest(ctx, reqUrl, "POST", headers, payloadBytes, types.FORM, c.HTTP, func(e *zerolog.Event) *zerolog.Event {
 		return e.Str("graphql_method", name)
 	})
 	if err == nil && resp != nil {

--- a/pkg/messagix/httpclient/http.go
+++ b/pkg/messagix/httpclient/http.go
@@ -568,8 +568,8 @@ func (c *HTTPClient) addInstagramHeaders(h *http.Header) {
 	}
 
 	if c.configs.BrowserConfigTable != nil {
-		if c.parent.GetCookies().IGWWWClaim != "" {
-			h.Set("x-ig-www-claim", c.parent.GetCookies().IGWWWClaim)
+		if wwwClaim := c.parent.GetCookies().GetWWWClaim(); wwwClaim != "" {
+			h.Set("x-ig-www-claim", wwwClaim)
 		}
 		h.Set("x-ig-app-id", c.configs.BrowserConfigTable.CurrentUserInitialData.AppID)
 	}

--- a/pkg/messagix/httpclient/http.go
+++ b/pkg/messagix/httpclient/http.go
@@ -35,6 +35,7 @@ type HTTPClient struct {
 	HTTP            *http.Client
 	HTTPSettings    exhttp.ClientSettings
 	websocketClient *http.Client
+	uploadClient    *http.Client
 	proxyAddr       string
 	GetNewProxy     func(reason string) (string, error)
 
@@ -80,6 +81,7 @@ func (c *HTTPClient) SetConfig(settings exhttp.ClientSettings) {
 	}
 	reqClient := req.C().ImpersonateChrome()
 	wsClient := req.C().ImpersonateChrome()
+	uploadReqClient := req.C().ImpersonateChrome()
 	forceHTTP1ChromeFingerprint(wsClient)
 	if DisableTLSVerification {
 		reqClient.SetTLSClientConfig(&tls.Config{
@@ -88,18 +90,33 @@ func (c *HTTPClient) SetConfig(settings exhttp.ClientSettings) {
 		wsClient.SetTLSClientConfig(&tls.Config{
 			InsecureSkipVerify: true,
 		})
+		uploadReqClient.SetTLSClientConfig(&tls.Config{
+			InsecureSkipVerify: true,
+		})
 	}
 
 	oldHTTP := c.HTTP
+	oldUpload := c.uploadClient
 	c.websocketClient = req.WithTransportOverride(c.HTTPSettings.WithGlobalTimeout(WebsocketHandshakeTimeout), wsClient).Compile()
 	c.HTTP = req.WithTransportOverride(c.HTTPSettings, reqClient).Compile()
 	c.HTTP.CheckRedirect = c.checkHTTPRedirect
+	uploadSettings := c.HTTPSettings.
+		WithGlobalTimeout(MediaUploadTimeout).
+		WithResponseHeaderTimeout(MediaUploadTimeout)
+	c.uploadClient = req.WithTransportOverride(uploadSettings, uploadReqClient).Compile()
+	c.uploadClient.CheckRedirect = c.checkHTTPRedirect
 	if oldHTTP != nil {
 		oldHTTP.CloseIdleConnections()
+	}
+	if oldUpload != nil {
+		oldUpload.CloseIdleConnections()
 	}
 
 	if DisableTLSVerification {
 		c.HTTP.Transport.(*http.Transport).TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		c.uploadClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}
 	}
@@ -195,6 +212,12 @@ func (c *HTTPClient) UpdateProxy(reason string) bool {
 
 var DisableTLSVerification = false
 var WebsocketHandshakeTimeout = 20 * time.Second
+
+// MediaUploadTimeout is used instead of the default timeouts for media uploads.
+// Uploading a large file takes much longer than the default global timeout, and the
+// server doesn't send response headers until it has received the entire body, which
+// means the default response header timeout applies to the upload itself.
+var MediaUploadTimeout = 5 * time.Minute
 
 func (c *HTTPClient) GetWebsocketDialer() *websocket.DialOptions {
 	if c == nil {
@@ -392,7 +415,23 @@ func (c *HTTPClient) MakeRequest(
 	payload []byte,
 	contentType types.ContentType,
 ) (*http.Response, []byte, error) {
-	return c.makeRequest(ctx, url, method, headers, payload, contentType, func(e *zerolog.Event) *zerolog.Event {
+	return c.makeRequest(ctx, url, method, headers, payload, contentType, c.HTTP, func(e *zerolog.Event) *zerolog.Event {
+		return e
+	})
+}
+
+// MakeUploadRequest is like MakeRequest, but uses the client with MediaUploadTimeout
+// instead of the default timeouts. It should be used for requests that send a whole
+// media file as the body.
+func (c *HTTPClient) MakeUploadRequest(
+	ctx context.Context,
+	url string,
+	method string,
+	headers http.Header,
+	payload []byte,
+	contentType types.ContentType,
+) (*http.Response, []byte, error) {
+	return c.makeRequest(ctx, url, method, headers, payload, contentType, c.uploadClient, func(e *zerolog.Event) *zerolog.Event {
 		return e
 	})
 }
@@ -409,13 +448,14 @@ func (c *HTTPClient) makeRequest(
 	headers http.Header,
 	payload []byte,
 	contentType types.ContentType,
+	httpClient *http.Client,
 	logContext func(e *zerolog.Event) *zerolog.Event,
 ) (*http.Response, []byte, error) {
 	var attempts int
 	for {
 		attempts++
 		start := time.Now()
-		resp, respDat, err := c.makeRequestDirect(ctx, url, method, headers, payload, contentType)
+		resp, respDat, err := c.makeRequestDirect(ctx, url, method, headers, payload, contentType, httpClient)
 		dur := time.Since(start)
 		if err == nil {
 			logContext(c.log.Debug()).
@@ -461,7 +501,7 @@ func (c *HTTPClient) makeRequest(
 	}
 }
 
-func (c *HTTPClient) makeRequestDirect(ctx context.Context, url string, method string, headers http.Header, payload []byte, contentType types.ContentType) (*http.Response, []byte, error) {
+func (c *HTTPClient) makeRequestDirect(ctx context.Context, url string, method string, headers http.Header, payload []byte, contentType types.ContentType, httpClient *http.Client) (*http.Response, []byte, error) {
 	newRequest, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(payload))
 	if err != nil {
 		return nil, nil, err
@@ -473,7 +513,7 @@ func (c *HTTPClient) makeRequestDirect(ctx context.Context, url string, method s
 
 	newRequest.Header = headers
 
-	response, err := c.HTTP.Do(newRequest)
+	response, err := httpClient.Do(newRequest)
 	defer func() {
 		if response != nil && response.Body != nil {
 			_ = response.Body.Close()

--- a/pkg/messagix/httpclient/mercury.go
+++ b/pkg/messagix/httpclient/mercury.go
@@ -91,7 +91,7 @@ func (c *HTTPClient) SendMercuryUploadRequest(ctx context.Context, threadID int6
 		h.Set("sec-fetch-mode", "cors")
 		h.Set("sec-fetch-site", "same-origin") // header is required
 
-		_, respBody, err := c.MakeRequest(ctx, url, http.MethodPost, h, payload, types.NONE)
+		_, respBody, err := c.MakeUploadRequest(ctx, url, http.MethodPost, h, payload, types.NONE)
 		if err != nil {
 			// MakeRequest retries itself, so bail immediately if that fails
 			return nil, fmt.Errorf("failed to send MercuryUploadRequest: %w", err)

--- a/pkg/msgconv/mediadl/upload.go
+++ b/pkg/msgconv/mediadl/upload.go
@@ -131,7 +131,7 @@ func reuploadVideoToMetaFallback(ctx context.Context, client *httpclient.HTTPCli
 	h.Add("x-fb-server-cluster", "True")
 	h.Add("x-zero-balance", "INIT")
 	h.Add("x-zero-eh", "")
-	resp, body, err := client.MakeRequest(
+	resp, body, err := client.MakeUploadRequest(
 		ctx,
 		fmt.Sprintf("https://rupload.facebook.com/messenger_video/%s", uploadID),
 		"POST",


### PR DESCRIPTION
A handful of bugs found while reading through the codebase, one commit each.

- **`client: close proxy response body`** — `getProxy` never closed the response
  body, on either the error or the success path. Only affects setups using
  `get_proxy_from`, but it runs on every connect and reconnect.
- **`handlemeta: don't dispatch parsed tables after context cancellation`** —
  the canceled-context branch logged that it wasn't dispatching, then dispatched.
  The queue-full path right below already drops the table in that case.
- **`client: fix inverted rate limit check when saving connection state`** — the
  check returned early exactly when the one-minute limit had elapsed, so state was
  dumped and written on every parsed table instead of once a minute.
- **`ig/chatsync: advance cursor when paginating chat backfill`** — the loop
  passed the same cursor to every `PaginateMailbox` call, re-fetching one page
  `BatchCount` times and then setting `BackfillCompleted`.
- **`instameow: don't dereference a missing mailbox in graphql responses`** — three
  unconditional dereferences of a pointer filled from the response; the one in
  `doChatBackfill` runs in a goroutine with no recover.
- **`messagix/cookies: fix data races on cookie storage`** — `MarshalJSON` and
  `UnmarshalJSON` were the only methods touching the map without the lock, and
  `MarshalJSON` runs on every `UserLogin.Save` while requests call
  `UpdateFromResponse`. Includes a test that reproduces it under `-race`.
- **`messagix/httpclient: use longer timeouts for media uploads`** (fixes #26) —
  the 20s response header timeout ends up applying to the upload body itself.
- **`connector: add identifiers to Facebook ghosts`** (fixes #149) — the Instagram
  connector sets them, the Facebook one didn't.

Verified with `go build`, `go vet`, `staticcheck` and `go test -race` over
`./pkg/...`. The two `cmd/` packages weren't built locally (no libolm on the
dev machine). The upload timeout change is reasoned from the code and compiles,
but I had no way to test it against a real upload — worth a second look.

PS : @radon-at-beeper , i really hope you'll find this good for you ! i really love the Beeper project