### PR TITLE
messagix/bloks,loginerrors: surface instagram login rate limits

### DIFF
--- a/pkg/loginerrors/errors.go
+++ b/pkg/loginerrors/errors.go
@@ -23,6 +23,7 @@ var (
 	NoSMSAvailable   = bridgev2.RespError{ErrCode: "FI.MAU.META_NO_SMS_AVAILABLE", Err: "Meta is refusing to send SMS codes right now. Try again later, or use/add a different MFA method for your Facebook account"}
 	MandatoryPasskey = bridgev2.RespError{ErrCode: "FI.MAU.META_PASSKEY_MANDATORY", Err: "Meta is requiring passkey sign-in which is not supported. Please try adding a different MFA method to your Facebook account from the official app/website", StatusCode: http.StatusBadRequest}
 	TokenExchange    = bridgev2.RespError{ErrCode: "FI.MAU.META_TOKEN_EXCHANGE_FAILED", Err: "Meta returned a temporary credential after login which could not be exchanged for a usable session. It may help to try again, or to log in from the official app/website first"}
+	RateLimited      = bridgev2.RespError{ErrCode: "FI.MAU.META_RATE_LIMITED", Err: "Meta is temporarily rate-limiting login attempts from this network. Please wait a few minutes and try again", StatusCode: http.StatusTooManyRequests}
 )
 
 func WithMessage(respError bridgev2.RespError, message string) bridgev2.RespError {

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -376,6 +376,8 @@ func instagramLoginSubmissionErrorDiagnostic(err error) (kind, detail string) {
 		return "unlinked_identifier", ""
 	case strings.Contains(message, "com.bloks.www.caa.assistive_login_confirmation"):
 		return "invalid_identifier", ""
+	case strings.Contains(message, "unexpected HTTP status 429"):
+		return "rate_limited", ""
 	}
 	match := instagramLoginSafeDiagnosticPattern.FindStringSubmatch(message)
 	if len(match) == 3 {
@@ -1317,6 +1319,8 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 				// comes up, but it's the only one sighted thus far. Update this if
 				// something new is discovered.
 				b.LastError = "Invalid email address"
+			} else if errorKind == "rate_limited" {
+				return nil, loginerrors.RateLimited
 			} else {
 				return nil, b.profile.unhandledCredentialError(err, errorKind, safeDetail)
 			}


### PR DESCRIPTION
Recognise 429s and return a dedicated rate-limit RespError so the user gets a clear "try again later" message instead.
