### PR TITLE
login: reverted login_web.go and implemented native login via web

### DIFF
--- a/pkg/igconnector/login.go
+++ b/pkg/igconnector/login.go
@@ -57,7 +57,7 @@ var (
 )
 
 func (ic *IGConnector) GetLoginFlows() []bridgev2.LoginFlow {
-	return []bridgev2.LoginFlow{loginFlowInstagramPassword, loginFlowInstagram}
+	return []bridgev2.LoginFlow{loginFlowInstagram, loginFlowInstagramPassword}
 }
 
 type MetaCookieLogin struct {

--- a/pkg/igconnector/login.go
+++ b/pkg/igconnector/login.go
@@ -57,7 +57,7 @@ var (
 )
 
 func (ic *IGConnector) GetLoginFlows() []bridgev2.LoginFlow {
-	return []bridgev2.LoginFlow{loginFlowInstagram, loginFlowInstagramPassword}
+	return []bridgev2.LoginFlow{loginFlowInstagramPassword, loginFlowInstagram}
 }
 
 type MetaCookieLogin struct {

--- a/pkg/igconnector/login_native.go
+++ b/pkg/igconnector/login_native.go
@@ -36,10 +36,12 @@ import (
 const (
 	FlowIDInstagramPassword = "instagram-password"
 
-	LoginStepIDCredentials = "fi.mau.meta.instagram.credentials"
+	LoginStepIDCredentials  = "fi.mau.meta.instagram.credentials"
+	LoginStepIDWebTwoFactor = "fi.mau.meta.instagram.web_two_factor"
 
-	loginFieldIdentifier = "username"
-	loginFieldPassword   = "password"
+	loginFieldIdentifier       = "username"
+	loginFieldPassword         = "password"
+	loginFieldWebTwoFactorCode = "verification_code"
 )
 
 var loginFlowInstagramPassword = bridgev2.LoginFlow{
@@ -95,16 +97,14 @@ type MetaNativeLogin struct {
 	User *bridgev2.User
 	Main *IGConnector
 
-	client     *instameow.Client
-	caaStarted bool
-	transport  http.RoundTripper
-	identifier string
-	password   string
+	client          *instameow.Client
+	transport       http.RoundTripper
+	webTwoFactor    *instameow.InstagramWebTwoFactorChallenge
+	webSessionReady bool
 }
 
 var _ bridgev2.LoginProcessUserInput = (*MetaNativeLogin)(nil)
 var _ bridgev2.LoginProcessWithParams = (*MetaNativeLogin)(nil)
-var _ bridgev2.LoginProcessDisplayAndWait = (*MetaNativeLogin)(nil)
 
 func (m *MetaNativeLogin) Start(ctx context.Context) (*bridgev2.LoginStep, error) {
 	return m.StartWithParams(ctx, bridgev2.LoginStartParams{})
@@ -120,15 +120,15 @@ func (m *MetaNativeLogin) StartWithParams(
 
 func (m *MetaNativeLogin) start(ctx context.Context, instructions string) (*bridgev2.LoginStep, error) {
 	m.client = nil
-	m.caaStarted = false
-	m.clearCredentials()
+	m.webTwoFactor = nil
+	m.webSessionReady = false
 	if m.User == nil || m.Main == nil {
 		return nil, errors.New("instagram login is not initialized")
 	}
 	loginCookies := &cookies.Cookies{Platform: types.Instagram}
 	loginCookies.UpdateValues(nil)
 	log := m.User.Log.With().Str("component", "instagram_login").Logger()
-	log.Debug().Bool("client_http", m.transport != nil).Msg("Starting Instagram native login flow")
+	log.Debug().Bool("client_http", m.transport != nil).Msg("Starting Instagram web password login flow")
 	var userID id.UserID
 	if m.User.User != nil {
 		userID = m.User.MXID
@@ -153,14 +153,9 @@ func (m *MetaNativeLogin) start(ctx context.Context, instructions string) (*brid
 
 func (m *MetaNativeLogin) Cancel() {
 	m.client = nil
-	m.caaStarted = false
+	m.webTwoFactor = nil
+	m.webSessionReady = false
 	m.transport = nil
-	m.clearCredentials()
-}
-
-func (m *MetaNativeLogin) clearCredentials() {
-	m.identifier = ""
-	m.password = ""
 }
 
 func (m *MetaNativeLogin) SubmitUserInput(
@@ -172,37 +167,72 @@ func (m *MetaNativeLogin) SubmitUserInput(
 			"This Instagram login session expired. Start the login again.",
 		), nil
 	}
-	if !m.caaStarted {
-		identifier := strings.TrimSpace(input[loginFieldIdentifier])
-		password := input[loginFieldPassword]
-		if identifier == "" || password == "" {
-			return instagramCredentialsStep(
-				"Enter both your Instagram email or username and password.",
+	if m.webSessionReady {
+		return m.continueWebAccountManager(ctx, input)
+	}
+	if m.webTwoFactor != nil {
+		verificationCode := strings.TrimSpace(input[loginFieldWebTwoFactorCode])
+		if verificationCode == "" {
+			return instagramWebTwoFactorStep(
+				m.webTwoFactor,
+				"Enter the verification code to continue creating the Instagram messaging session.",
 			), nil
 		}
-		m.identifier = identifier
-		m.password = password
+		err := m.client.CompleteInstagramWebSessionTwoFactor(ctx, verificationCode)
+		if err != nil {
+			if isClientHTTPError(err) {
+				m.User.Log.Warn().Err(err).Msg("Instagram web two-factor request failed on the client")
+				return instagramWebTwoFactorStep(
+					m.webTwoFactor,
+					"The request did not complete on this device. Enter a fresh verification code and try again.",
+				), nil
+			} else if errors.Is(err, instameow.ErrInstagramWebTwoFactorCodeRejected) {
+				return instagramWebTwoFactorStep(
+					m.webTwoFactor,
+					"Instagram did not accept that code. Enter a new code and try again.",
+				), nil
+			}
+			return nil, fmt.Errorf("failed to complete Instagram web two-factor login: %w", err)
+		}
+		m.webTwoFactor = nil
+		m.webSessionReady = true
+		return m.continueWebAccountManager(ctx, input)
 	}
-	m.caaStarted = true
 
-	step, err := m.client.DoInstagramCAALoginSteps(ctx, input)
+	identifier := strings.TrimSpace(input[loginFieldIdentifier])
+	password := input[loginFieldPassword]
+	if identifier == "" || password == "" {
+		return instagramCredentialsStep(
+			"Enter both your Instagram email or username and password.",
+		), nil
+	}
+	challenge, err := m.client.CreateInstagramWebSession(ctx, identifier, password)
 	if err != nil {
 		if isClientHTTPError(err) {
-			m.User.Log.Warn().Err(err).Msg("Instagram login request failed on the client")
+			m.User.Log.Warn().Err(err).Msg("Instagram web login request failed on the client")
 			return m.start(ctx, "The request did not complete on this device. Please try again.")
 		}
-		m.clearCredentials()
-		return nil, fmt.Errorf("failed to log in to Instagram through CAA: %w", err)
+		return nil, fmt.Errorf("failed to create Instagram web session: %w", err)
 	}
-	if step != nil {
-		return step, nil
+	if challenge != nil {
+		m.webTwoFactor = challenge
+		return instagramWebTwoFactorStep(challenge, ""), nil
 	}
-	m.clearCredentials()
-	return m.complete(ctx)
+	m.webSessionReady = true
+	return m.continueWebAccountManager(ctx, input)
 }
 
-func (m *MetaNativeLogin) Wait(ctx context.Context) (*bridgev2.LoginStep, error) {
-	return m.SubmitUserInput(ctx, map[string]string{})
+func (m *MetaNativeLogin) continueWebAccountManager(
+	ctx context.Context,
+	input map[string]string,
+) (*bridgev2.LoginStep, error) {
+	step, err := m.client.DoInstagramWebAccountManagerSteps(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select Instagram web Account Manager profile: %w", err)
+	} else if step != nil {
+		return step, nil
+	}
+	return m.complete(ctx)
 }
 
 func (m *MetaNativeLogin) complete(ctx context.Context) (*bridgev2.LoginStep, error) {
@@ -254,6 +284,37 @@ func instagramCredentialsStep(instructions string) *bridgev2.LoginStep {
 					ID:          loginFieldPassword,
 					Name:        "Password",
 					Description: "Your Instagram password.",
+				},
+			},
+		},
+	}
+}
+
+func instagramWebTwoFactorStep(
+	challenge *instameow.InstagramWebTwoFactorChallenge,
+	instructions string,
+) *bridgev2.LoginStep {
+	if instructions == "" {
+		switch {
+		case challenge != nil && challenge.TOTP:
+			instructions = "Enter the verification code from your authenticator app."
+		case challenge != nil && (challenge.SMS || challenge.WhatsApp):
+			instructions = "Enter the verification code Instagram sent to you."
+		default:
+			instructions = "Enter your Instagram verification code."
+		}
+	}
+	return &bridgev2.LoginStep{
+		Type:         bridgev2.LoginStepTypeUserInput,
+		StepID:       LoginStepIDWebTwoFactor,
+		Instructions: instructions,
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{
+				{
+					Type:        bridgev2.LoginInputFieldType2FACode,
+					ID:          loginFieldWebTwoFactorCode,
+					Name:        "Verification code",
+					Description: "The verification code for your Instagram account.",
 				},
 			},
 		},

--- a/pkg/instameow/client.go
+++ b/pkg/instameow/client.go
@@ -46,6 +46,8 @@ type Client struct {
 
 	mobileLogin           *mobileLoginState
 	caaLogin              *instagramCAALoginState
+	webTwoFactor          *instagramWebTwoFactorState
+	webAccountManager     *instagramWebAccountManagerState
 	mobileLoginDevice     *types.InstagramLoginDevice
 	mobileSession         *instagramMobileSession
 	saveMobileLoginDevice func(context.Context, types.InstagramLoginDevice) error

--- a/pkg/instameow/login_account_manager.go
+++ b/pkg/instameow/login_account_manager.go
@@ -77,6 +77,18 @@ type instagramAccountManagerWebLoginResponse struct {
 	Authenticated bool `json:"authenticated"`
 }
 
+type instagramWebAccountManagerResponse struct {
+	IGAccounts []struct {
+		Username string `json:"username"`
+	} `json:"igAccounts"`
+}
+
+type instagramWebAccountManagerState struct {
+	Accounts  []instagramAccountManagerAccount
+	CSRFToken string
+	Complete  bool
+}
+
 func newInstagramAccountManagerToken(session *instagramMobileSession) instagramAccountManagerToken {
 	return instagramAccountManagerToken{
 		AccountType: "Instagram",
@@ -409,6 +421,114 @@ func (c *Client) switchInstagramAccountManagerWebAccount(
 		return errors.New("instagram Account Manager did not authenticate the selected web profile")
 	}
 	return nil
+}
+
+func (c *Client) getInstagramWebAccountManagerAccounts(
+	ctx context.Context,
+	currentUsername string,
+) ([]instagramAccountManagerAccount, error) {
+	if c == nil {
+		return nil, ErrClientIsNil
+	}
+	headers := c.http.BuildHeaders(true, false)
+	headers.Set("origin", c.GetEndpoint("base_url"))
+	headers.Set("referer", c.GetEndpoint("messages"))
+	headers.Set("x-requested-with", "XMLHttpRequest")
+	headers.Set("sec-fetch-dest", "empty")
+	headers.Set("sec-fetch-mode", "cors")
+	headers.Set("sec-fetch-site", "same-origin")
+	response, body, requestErr := c.http.MakeRequest(
+		ctx,
+		c.GetEndpoint("fxcal_sso_users"),
+		http.MethodPost,
+		headers,
+		nil,
+		types.NONE,
+	)
+	if response != nil {
+		c.cookies.UpdateFromResponse(response)
+	}
+	if requestErr != nil {
+		return nil, instagramAccountManagerRequestError(
+			"failed to load Instagram web Account Manager profiles",
+			response,
+			body,
+			requestErr,
+		)
+	}
+	var result instagramWebAccountManagerResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse Instagram web Account Manager profiles: %w", err)
+	}
+	accounts := []instagramAccountManagerAccount{{Username: currentUsername}}
+	seen := map[string]bool{strings.ToLower(currentUsername): true}
+	for _, account := range result.IGAccounts {
+		username := strings.TrimSpace(account.Username)
+		key := strings.ToLower(username)
+		if username != "" && !seen[key] {
+			seen[key] = true
+			accounts = append(accounts, instagramAccountManagerAccount{Username: username})
+		}
+	}
+	return accounts, nil
+}
+
+func (c *Client) DoInstagramWebAccountManagerSteps(
+	ctx context.Context,
+	userInput map[string]string,
+) (*bridgev2.LoginStep, error) {
+	if c == nil {
+		return nil, ErrClientIsNil
+	}
+	state := c.webAccountManager
+	if state == nil {
+		if err := c.loadIndex(ctx); err != nil {
+			return nil, fmt.Errorf("failed to load the current Instagram web session: %w", err)
+		}
+		currentUsername := strings.TrimSpace(c.configs.BrowserConfigTable.PolarisViewer.GetUsername())
+		if currentUsername == "" {
+			return nil, errors.New("instagram web login did not return the current profile")
+		}
+		accounts, err := c.getInstagramWebAccountManagerAccounts(ctx, currentUsername)
+		if err != nil {
+			return nil, err
+		}
+		state = &instagramWebAccountManagerState{
+			Accounts:  accounts,
+			CSRFToken: c.cookies.Get(cookies.IGCookieCSRFToken),
+			Complete:  len(accounts) == 1,
+		}
+		c.webAccountManager = state
+	}
+	if state.Complete {
+		return nil, nil
+	}
+	selectedUsername := strings.TrimSpace(userInput[instagramAccountManagerField])
+	if selectedUsername == "" {
+		return instagramAccountManagerSelectionStep(state.Accounts), nil
+	}
+	for i := range state.Accounts {
+		selectedAccount := &state.Accounts[i]
+		if !strings.EqualFold(selectedAccount.Username, selectedUsername) {
+			continue
+		}
+		if i != 0 {
+			if err := c.switchInstagramAccountManagerWebAccount(ctx, selectedAccount.Username); err != nil {
+				return nil, err
+			} else if err := c.loadIndex(ctx); err != nil {
+				return nil, fmt.Errorf("failed to load the selected Instagram web session: %w", err)
+			}
+			if c.cookies.Get(cookies.IGCookieCSRFToken) == "" {
+				c.cookies.Set(cookies.IGCookieCSRFToken, state.CSRFToken)
+			}
+			if !strings.EqualFold(c.configs.BrowserConfigTable.PolarisViewer.GetUsername(), selectedAccount.Username) {
+				return nil, errors.New("instagram Account Manager web login returned the wrong profile")
+			}
+		}
+		state.Complete = true
+		return nil, nil
+	}
+	return nil, errors.New("invalid Instagram web Account Manager profile selection")
 }
 
 func instagramAccountManagerSelectionStep(

--- a/pkg/instameow/login_web.go
+++ b/pkg/instameow/login_web.go
@@ -1,0 +1,640 @@
+// mautrix-meta - A Matrix-Facebook Messenger and Instagram DM puppeting bridge.
+// Copyright (C) 2026 Killian Lelong
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package instameow
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-querystring/query"
+
+	"go.mau.fi/mautrix-meta/pkg/messagix/cookies"
+	"go.mau.fi/mautrix-meta/pkg/messagix/crypto"
+	"go.mau.fi/mautrix-meta/pkg/messagix/httpclient"
+	"go.mau.fi/mautrix-meta/pkg/messagix/types"
+)
+
+const instagramWebTwoFactorValidateCodeDocID = "26264014419868193"
+
+var ErrInstagramWebTwoFactorCodeRejected = errors.New("instagram web two-factor code was rejected")
+
+type InstagramWebTwoFactorChallenge struct {
+	TOTP     bool
+	SMS      bool
+	WhatsApp bool
+}
+
+type instagramWebTwoFactorInfo struct {
+	Identifier        string `json:"two_factor_identifier"`
+	Username          string `json:"username"`
+	TOTP              bool   `json:"totp_two_factor_on"`
+	SMS               bool   `json:"sms_two_factor_on"`
+	WhatsApp          bool   `json:"whatsapp_two_factor_on"`
+	EncryptedContext  string `json:"encrypted_context"`
+	MaskedPhoneNumber string `json:"obfuscated_phone_number_2"`
+}
+
+type instagramWebTwoFactorState struct {
+	identifier         string
+	username           string
+	encryptedContext   string
+	maskedContactPoint string
+	method             string
+}
+
+type instagramWebLoginResponse struct {
+	Authenticated     bool                      `json:"authenticated"`
+	TwoFactorRequired bool                      `json:"two_factor_required"`
+	Message           string                    `json:"message"`
+	Status            string                    `json:"status"`
+	ErrorType         string                    `json:"error_type"`
+	CheckpointURL     string                    `json:"checkpoint_url"`
+	RedirectURL       string                    `json:"redirect_url"`
+	TwoFactorInfo     instagramWebTwoFactorInfo `json:"two_factor_info"`
+}
+
+func instagramWebSprinkleToken(csrfToken string, config types.SprinkleConfig) (string, error) {
+	if csrfToken == "" {
+		return "", errors.New("instagram web login is missing a CSRF token")
+	} else if config.ParamName == "" {
+		return "", errors.New("instagram web login page did not include sprinkle configuration")
+	} else if !config.ShouldRandomize && config.Version <= 0 {
+		return "", errors.New("instagram web login page included an invalid sprinkle version")
+	}
+	sum := 0
+	for _, character := range csrfToken {
+		sum += int(character)
+	}
+	token := strconv.Itoa(sum)
+	if !config.ShouldRandomize {
+		token = strconv.Itoa(config.Version) + token
+	}
+	return token, nil
+}
+
+func newInstagramWebLoginForm(
+	identifier,
+	encryptedPassword,
+	csrfToken string,
+	sprinkleConfig types.SprinkleConfig,
+) (url.Values, error) {
+	sprinkleToken, err := instagramWebSprinkleToken(csrfToken, sprinkleConfig)
+	if err != nil {
+		return nil, err
+	}
+	form := url.Values{
+		"caaF2DebugGroup":             {"-1"},
+		"enc_password":                {encryptedPassword},
+		"isPrivacyPortalReq":          {"false"},
+		"loginAttemptSubmissionCount": {"0"},
+		"optIntoOneTap":               {"false"},
+		"queryParams":                 {"{}"},
+		"stopDeletionNonce":           {""},
+		"trustedDeviceRecords":        {"{}"},
+		"username":                    {identifier},
+	}
+	form.Set(sprinkleConfig.ParamName, sprinkleToken)
+	return form, nil
+}
+
+func newInstagramWebTwoFactorForm(
+	state *instagramWebTwoFactorState,
+	verificationCode,
+	csrfToken string,
+	sprinkleConfig types.SprinkleConfig,
+) (url.Values, error) {
+	if state == nil || state.identifier == "" || state.username == "" {
+		return nil, errors.New("instagram web two-factor challenge is missing state")
+	}
+	sprinkleToken, err := instagramWebSprinkleToken(csrfToken, sprinkleConfig)
+	if err != nil {
+		return nil, err
+	}
+	form := url.Values{
+		"identifier":        {state.identifier},
+		"queryParams":       {"{}"},
+		"trust_this_device": {"1"},
+		"username":          {state.username},
+		"verificationCode":  {verificationCode},
+	}
+	form.Set(sprinkleConfig.ParamName, sprinkleToken)
+	return form, nil
+}
+
+func (c *Client) addInstagramWebLoginHeaders(headers http.Header) error {
+	if c.configs == nil || c.configs.BrowserConfigTable == nil {
+		return errors.New("instagram web login page configuration is missing")
+	}
+	config := c.configs.BrowserConfigTable
+	if config.InstagramWebPushInfo.RolloutHash == "" {
+		return errors.New("instagram web login page did not include a rollout hash")
+	} else if c.configs.WebSessionID == "" {
+		return errors.New("instagram web login is missing a web session ID")
+	} else if headers.Get("x-csrftoken") == "" {
+		return errors.New("instagram web login is missing the CSRF header")
+	} else if headers.Get("x-ig-app-id") == "" {
+		return errors.New("instagram web login page did not include an app ID")
+	}
+	headers.Set("x-instagram-ajax", config.InstagramWebPushInfo.RolloutHash)
+	headers.Set("x-web-session-id", c.configs.WebSessionID)
+	if c.cookies.IGWWWClaim == "" {
+		headers.Set("x-ig-www-claim", "0")
+	} else {
+		headers.Set("x-ig-www-claim", c.cookies.IGWWWClaim)
+	}
+	if config.PolarisSiteData.SendDeviceIDHeader {
+		if config.PolarisSiteData.DeviceID == "" {
+			return errors.New("instagram web login page requested an empty web device ID")
+		}
+		headers.Set("x-web-device-id", config.PolarisSiteData.DeviceID)
+	}
+	return nil
+}
+
+func instagramWebLoginResponseKind(body []byte) string {
+	trimmed := bytes.TrimSpace(body)
+	switch {
+	case len(trimmed) == 0:
+		return "empty"
+	case json.Valid(trimmed):
+		return "json"
+	case bytes.HasPrefix(trimmed, []byte("for (;;);")):
+		return "prefixed_json"
+	case trimmed[0] == '<':
+		return "html"
+	default:
+		return "other"
+	}
+}
+
+func instagramWebLoginResponseKeys(body []byte) []string {
+	var response map[string]json.RawMessage
+	if json.Unmarshal(body, &response) != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(response))
+	for key := range response {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func instagramWebLoginResponseClass(result instagramWebLoginResponse) string {
+	detail := strings.ToLower(result.Message + " " + result.ErrorType)
+	switch {
+	case result.TwoFactorRequired:
+		return "two_factor_required"
+	case result.CheckpointURL != "" || result.RedirectURL != "" ||
+		strings.Contains(detail, "checkpoint") || strings.Contains(detail, "challenge"):
+		return "challenge_required"
+	case strings.Contains(detail, "feedback_required") || strings.Contains(detail, "rate") ||
+		strings.Contains(detail, "wait") || strings.Contains(detail, "try again later"):
+		return "temporarily_blocked"
+	case strings.Contains(detail, "password") || strings.Contains(detail, "credential") ||
+		strings.Contains(detail, "username") || strings.Contains(detail, "user_not_found"):
+		return "credentials_rejected"
+	case strings.Contains(detail, "consent"):
+		return "consent_required"
+	case strings.Contains(detail, "disabled") || strings.Contains(detail, "suspended"):
+		return "account_restricted"
+	case result.Message != "" || result.ErrorType != "":
+		return "provider_error"
+	default:
+		return "unclassified"
+	}
+}
+
+func instagramWebFormFields(form url.Values) []string {
+	fields := make([]string, 0, len(form))
+	for field := range form {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+func (c *Client) logInstagramWebRequestRejection(
+	message string,
+	requestErr error,
+	response *http.Response,
+	body []byte,
+	headers http.Header,
+	form url.Values,
+	responseClass string,
+) {
+	logEvent := c.log.Warn().
+		Err(requestErr).
+		Int("response_bytes", len(body)).
+		Str("response_kind", instagramWebLoginResponseKind(body)).
+		Bool("csrf_header_present", headers.Get("x-csrftoken") != "").
+		Bool("cookie_header_present", headers.Get("cookie") != "").
+		Bool("instagram_ajax_header_present", headers.Get("x-instagram-ajax") != "").
+		Bool("web_session_header_present", headers.Get("x-web-session-id") != "").
+		Bool("web_device_header_present", headers.Get("x-web-device-id") != "").
+		Str("response_class", responseClass).
+		Strs("response_keys", instagramWebLoginResponseKeys(body)).
+		Strs("form_fields", instagramWebFormFields(form))
+	if response != nil {
+		logEvent = logEvent.
+			Int("status_code", response.StatusCode).
+			Str("content_type", response.Header.Get("content-type"))
+	}
+	logEvent.Msg(message)
+}
+
+func (c *Client) captureInstagramWebTwoFactor(
+	result instagramWebLoginResponse,
+	fallbackUsername string,
+) (*InstagramWebTwoFactorChallenge, error) {
+	info := result.TwoFactorInfo
+	username := info.Username
+	if username == "" {
+		username = fallbackUsername
+	}
+	if info.EncryptedContext == "" && (info.Identifier == "" || username == "") {
+		return nil, errors.New("instagram web two-factor response is missing its challenge identifier")
+	}
+	method := ""
+	switch {
+	case info.TOTP:
+		method = "TOTP"
+	case info.SMS:
+		method = "SMS"
+	case info.WhatsApp:
+		method = "WHATSAPP"
+	}
+	if info.EncryptedContext != "" && method == "" {
+		return nil, errors.New("instagram web two-factor response uses an unsupported verification method")
+	}
+	maskedContactPoint := ""
+	if method == "SMS" || method == "WHATSAPP" {
+		maskedContactPoint = info.MaskedPhoneNumber
+	}
+	c.webTwoFactor = &instagramWebTwoFactorState{
+		identifier:         info.Identifier,
+		username:           username,
+		encryptedContext:   info.EncryptedContext,
+		maskedContactPoint: maskedContactPoint,
+		method:             method,
+	}
+	return &InstagramWebTwoFactorChallenge{
+		TOTP:     info.TOTP,
+		SMS:      info.SMS,
+		WhatsApp: info.WhatsApp,
+	}, nil
+}
+
+// CreateInstagramWebSession creates a session that can be used by Instagram's
+// web messaging APIs and realtime stream. A returned challenge must be
+// completed with CompleteInstagramWebSessionTwoFactor.
+func (c *Client) CreateInstagramWebSession(
+	ctx context.Context,
+	identifier,
+	password string,
+) (*InstagramWebTwoFactorChallenge, error) {
+	if c == nil {
+		return nil, ErrClientIsNil
+	} else if identifier == "" || password == "" {
+		return nil, errors.New("instagram web login is missing credentials")
+	}
+	c.webTwoFactor = nil
+	c.webAccountManager = nil
+
+	// Keep only stable device cookies between attempts. Loading the login page
+	// below refreshes the remaining unauthenticated web-session state.
+	c.cookies.UpdateValues(map[cookies.MetaCookieName]string{
+		cookies.IGCookieMachineID: c.cookies.Get(cookies.IGCookieMachineID),
+		cookies.IGCookieDeviceID:  c.cookies.Get(cookies.IGCookieDeviceID),
+	})
+	c.cookies.IGWWWClaim = ""
+
+	c.configs = httpclient.NewConfigs(c)
+	c.http.SetConfigs(c.configs)
+	moduleLoader := httpclient.NewModuleParser(c, c.http, c.configs)
+	moduleLoader.LS = nil
+	baseURL := c.GetEndpoint("base_url")
+	loginPageURL := c.GetEndpoint("login")
+	if err := moduleLoader.Load(ctx, loginPageURL); err != nil {
+		return nil, fmt.Errorf("failed to load Instagram web login page: %w", err)
+	}
+	c.configs.Setup(false)
+
+	encryption := c.configs.BrowserConfigTable.InstagramPasswordEncryption
+	keyID, err := strconv.Atoi(encryption.KeyID)
+	if err != nil || keyID <= 0 || encryption.PublicKey == "" {
+		return nil, errors.New("instagram web login page did not include password encryption keys")
+	}
+	encryptedPassword, err := crypto.EncryptInstagramWebPassword(
+		keyID,
+		encryption.PublicKey,
+		password,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt Instagram web password: %w", err)
+	}
+
+	form, err := newInstagramWebLoginForm(
+		identifier,
+		encryptedPassword,
+		c.cookies.Get(cookies.IGCookieCSRFToken),
+		c.configs.BrowserConfigTable.SprinkleConfig,
+	)
+	if err != nil {
+		return nil, err
+	}
+	headers := c.http.BuildHeaders(true, false)
+	headers.Set("origin", baseURL)
+	headers.Set("referer", loginPageURL)
+	headers.Set("x-requested-with", "XMLHttpRequest")
+	headers.Set("sec-fetch-dest", "empty")
+	headers.Set("sec-fetch-mode", "cors")
+	headers.Set("sec-fetch-site", "same-origin")
+	if err = c.addInstagramWebLoginHeaders(headers); err != nil {
+		return nil, err
+	}
+	response, body, requestErr := c.http.MakeRequest(
+		ctx,
+		c.GetEndpoint("login_ajax"),
+		http.MethodPost,
+		headers,
+		[]byte(form.Encode()),
+		types.FORM,
+	)
+	if response != nil {
+		c.cookies.UpdateFromResponse(response)
+	}
+	var result instagramWebLoginResponse
+	parseErr := json.Unmarshal(body, &result)
+	if requestErr != nil {
+		c.logInstagramWebRequestRejection(
+			"Instagram web login request was rejected",
+			requestErr,
+			response,
+			body,
+			headers,
+			form,
+			instagramWebLoginResponseClass(result),
+		)
+		if parseErr == nil && result.TwoFactorRequired {
+			return c.captureInstagramWebTwoFactor(result, identifier)
+		} else if parseErr == nil && result.Message != "" {
+			return nil, fmt.Errorf("instagram web login failed: %s", result.Message)
+		}
+		return nil, fmt.Errorf("instagram web login request failed: %w", requestErr)
+	} else if response == nil {
+		return nil, errors.New("instagram web login returned no response")
+	} else if parseErr != nil {
+		return nil, fmt.Errorf("failed to parse Instagram web login: %w", parseErr)
+	} else if result.TwoFactorRequired {
+		return c.captureInstagramWebTwoFactor(result, identifier)
+	} else if !result.Authenticated {
+		if result.Message != "" {
+			return nil, fmt.Errorf("instagram web login failed: %s", result.Message)
+		}
+		return nil, errors.New("instagram web login did not authenticate")
+	} else if missing := c.cookies.GetMissingCookieNames(); len(missing) > 0 {
+		return nil, fmt.Errorf("instagram web login succeeded without required cookies: %v", missing)
+	}
+	return nil, nil
+}
+
+type instagramWebTwoFactorSensitiveCode struct {
+	Value string `json:"sensitive_string_value"`
+}
+
+type instagramWebTwoFactorGraphQLVariables struct {
+	Code               instagramWebTwoFactorSensitiveCode `json:"code"`
+	EncryptedContext   string                             `json:"encryptedContext"`
+	Flow               string                             `json:"flow"`
+	MaskedContactPoint *string                            `json:"maskedContactPoint"`
+	Method             string                             `json:"method"`
+	NextURI            *string                            `json:"next_uri"`
+	SharedPrefsData    *string                            `json:"shared_prefs_data"`
+	TrustThisDevice    bool                               `json:"trust_this_device"`
+}
+
+type instagramWebTwoFactorGraphQLResponse struct {
+	Data *struct {
+		ValidateCode *struct {
+			IsCodeValid bool `json:"is_code_valid"`
+		} `json:"xfb_two_factor_login_validate_code"`
+	} `json:"data"`
+}
+
+func (c *Client) newInstagramWebTwoFactorGraphQLForm(
+	state *instagramWebTwoFactorState,
+	verificationCode string,
+) (url.Values, error) {
+	if state == nil || state.encryptedContext == "" || state.method == "" {
+		return nil, errors.New("instagram encrypted web two-factor challenge is missing state")
+	}
+	var maskedContactPoint *string
+	if state.maskedContactPoint != "" {
+		maskedContactPoint = &state.maskedContactPoint
+	}
+	variables, err := json.Marshal(instagramWebTwoFactorGraphQLVariables{
+		Code: instagramWebTwoFactorSensitiveCode{
+			Value: verificationCode,
+		},
+		EncryptedContext:   state.encryptedContext,
+		Flow:               "TWO_FACTOR_LOGIN",
+		MaskedContactPoint: maskedContactPoint,
+		Method:             state.method,
+		TrustThisDevice:    true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Instagram web two-factor request: %w", err)
+	}
+	requestQuery := c.http.NewHTTPQuery()
+	requestQuery.FbAPICallerClass = "RelayModern"
+	requestQuery.FbAPIReqFriendlyName = "useTwoFactorLoginValidateCodeMutation"
+	requestQuery.Variables = string(variables)
+	requestQuery.ServerTimestamps = "true"
+	requestQuery.DocID = instagramWebTwoFactorValidateCodeDocID
+	form, err := query.Values(requestQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Instagram web two-factor request: %w", err)
+	}
+	sprinkleToken, err := instagramWebSprinkleToken(
+		c.cookies.Get(cookies.IGCookieCSRFToken),
+		c.configs.BrowserConfigTable.SprinkleConfig,
+	)
+	if err != nil {
+		return nil, err
+	}
+	form.Set(c.configs.BrowserConfigTable.SprinkleConfig.ParamName, sprinkleToken)
+	return form, nil
+}
+
+func (c *Client) completeInstagramWebTwoFactorLegacy(
+	ctx context.Context,
+	state *instagramWebTwoFactorState,
+	verificationCode string,
+) error {
+	form, err := newInstagramWebTwoFactorForm(
+		state,
+		verificationCode,
+		c.cookies.Get(cookies.IGCookieCSRFToken),
+		c.configs.BrowserConfigTable.SprinkleConfig,
+	)
+	if err != nil {
+		return err
+	}
+	headers := c.http.BuildHeaders(true, false)
+	headers.Set("origin", c.GetEndpoint("base_url"))
+	headers.Set("referer", c.GetEndpoint("login_two_factor"))
+	headers.Set("x-requested-with", "XMLHttpRequest")
+	headers.Set("sec-fetch-dest", "empty")
+	headers.Set("sec-fetch-mode", "cors")
+	headers.Set("sec-fetch-site", "same-origin")
+	if err = c.addInstagramWebLoginHeaders(headers); err != nil {
+		return err
+	}
+	response, body, requestErr := c.http.MakeRequest(
+		ctx,
+		c.GetEndpoint("login_two_factor_ajax"),
+		http.MethodPost,
+		headers,
+		[]byte(form.Encode()),
+		types.FORM,
+	)
+	if response != nil {
+		c.cookies.UpdateFromResponse(response)
+	}
+	var result instagramWebLoginResponse
+	parseErr := json.Unmarshal(body, &result)
+	if requestErr != nil {
+		c.logInstagramWebRequestRejection(
+			"Instagram web two-factor request was rejected",
+			requestErr,
+			response,
+			body,
+			headers,
+			form,
+			instagramWebLoginResponseClass(result),
+		)
+		if response != nil && response.StatusCode >= 400 && response.StatusCode < 500 && parseErr == nil {
+			return ErrInstagramWebTwoFactorCodeRejected
+		}
+		return fmt.Errorf("instagram web two-factor request failed: %w", requestErr)
+	} else if response == nil {
+		return errors.New("instagram web two-factor login returned no response")
+	} else if parseErr != nil {
+		return fmt.Errorf("failed to parse Instagram web two-factor login: %w", parseErr)
+	} else if !result.Authenticated && !strings.EqualFold(result.Status, "ok") {
+		return ErrInstagramWebTwoFactorCodeRejected
+	}
+	return nil
+}
+
+func (c *Client) completeInstagramWebTwoFactorEncrypted(
+	ctx context.Context,
+	state *instagramWebTwoFactorState,
+	verificationCode string,
+) error {
+	form, err := c.newInstagramWebTwoFactorGraphQLForm(state, verificationCode)
+	if err != nil {
+		return err
+	}
+	headers := c.http.BuildHeaders(true, false)
+	headers.Set("origin", c.GetEndpoint("base_url"))
+	headers.Set("referer", c.GetEndpoint("login_two_step_verification"))
+	headers.Set("x-fb-friendly-name", "useTwoFactorLoginValidateCodeMutation")
+	headers.Set("sec-fetch-dest", "empty")
+	headers.Set("sec-fetch-mode", "cors")
+	headers.Set("sec-fetch-site", "same-origin")
+	if err = c.addInstagramWebLoginHeaders(headers); err != nil {
+		return err
+	}
+	response, body, requestErr := c.http.MakeRequest(
+		ctx,
+		c.GetEndpoint("graphql"),
+		http.MethodPost,
+		headers,
+		[]byte(form.Encode()),
+		types.FORM,
+	)
+	if response != nil {
+		c.cookies.UpdateFromResponse(response)
+	}
+	body = bytes.TrimPrefix(body, httpclient.AntiJSPrefix)
+	var result instagramWebTwoFactorGraphQLResponse
+	parseErr := json.Unmarshal(body, &result)
+	if requestErr != nil {
+		c.logInstagramWebRequestRejection(
+			"Instagram encrypted web two-factor request was rejected",
+			requestErr,
+			response,
+			body,
+			headers,
+			form,
+			"two_factor_code_rejected",
+		)
+		if response != nil && response.StatusCode >= 400 && response.StatusCode < 500 && parseErr == nil {
+			return ErrInstagramWebTwoFactorCodeRejected
+		}
+		return fmt.Errorf("instagram encrypted web two-factor request failed: %w", requestErr)
+	} else if response == nil {
+		return errors.New("instagram encrypted web two-factor login returned no response")
+	} else if parseErr != nil {
+		return fmt.Errorf("failed to parse Instagram encrypted web two-factor login: %w", parseErr)
+	} else if result.Data == nil || result.Data.ValidateCode == nil || !result.Data.ValidateCode.IsCodeValid {
+		return ErrInstagramWebTwoFactorCodeRejected
+	}
+	return nil
+}
+
+// CompleteInstagramWebSessionTwoFactor finishes a challenge returned by
+// CreateInstagramWebSession. Challenge identifiers and codes remain in memory
+// for the lifetime of the Bridgev2 login process and are never logged.
+func (c *Client) CompleteInstagramWebSessionTwoFactor(
+	ctx context.Context,
+	verificationCode string,
+) error {
+	if c == nil {
+		return ErrClientIsNil
+	} else if c.webTwoFactor == nil {
+		return errors.New("instagram web two-factor challenge is not active")
+	}
+	verificationCode = strings.TrimSpace(verificationCode)
+	if verificationCode == "" {
+		return errors.New("instagram web two-factor code is empty")
+	}
+	state := c.webTwoFactor
+	var err error
+	if state.encryptedContext == "" {
+		err = c.completeInstagramWebTwoFactorLegacy(ctx, state, verificationCode)
+	} else {
+		err = c.completeInstagramWebTwoFactorEncrypted(ctx, state, verificationCode)
+	}
+	if err != nil {
+		return err
+	} else if missing := c.cookies.GetMissingCookieNames(); len(missing) > 0 {
+		return fmt.Errorf("instagram web two-factor login succeeded without required cookies: %v", missing)
+	}
+	c.webTwoFactor = nil
+	return nil
+}

--- a/pkg/messagix/endpoints/instagram.go
+++ b/pkg/messagix/endpoints/instagram.go
@@ -18,6 +18,7 @@ var InstagramEndpoints = map[string]string{
 	"login_two_factor":            instaBaseUrl + "/accounts/login/two_factor/",
 	"login_two_factor_ajax":       instaWebApiV1Url + "/accounts/login/ajax/two_factor/",
 	"login_two_step_verification": instaBaseUrl + "/accounts/login/two_step_verification/",
+	"fxcal_sso_users":             instaWebApiV1Url + "/fxcal/ig_sso_users/",
 	"fxcal_sso_login":             instaWebApiV1Url + "/fxcal/ig_sso_login/",
 	"thread":                      instaBaseUrl + "/direct/t/",
 	"graphql":                     instaBaseUrl + "/api/graphql",


### PR DESCRIPTION
Changelog:
- reverted `login_web` deletion
- handles accounts with multiple instagram profiles (login_account_manager.go)
- replaced the mobile login entrypoint with web (login_native)

Tested on cloud and selfhost, on an account with 2FA & Account Manager with both Profiles

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
