### PR TITLE
msgconv/xma: render GraphQL CTA buttons with action_url as links

### DIFF
--- a/pkg/msgconv/igconv/xma.go
+++ b/pkg/msgconv/igconv/xma.go
@@ -84,6 +84,17 @@ func (mc *MessageConverter) wrapXMACaption(ctx context.Context, xma *slidetypes.
 		targetURL.RawQuery = ""
 		captionHTML += fmt.Sprintf(`<p><a href="%s">%s</a></p>`, html.EscapeString(fullTargetURL), html.EscapeString(targetURL.String()))
 	}
+	var buttons strings.Builder
+	for _, cta := range xma.CTAButtons {
+		if cta == nil || cta.Title == "" || cta.ActionURL == "" {
+			continue
+		}
+		fmt.Fprintf(&buttons, `<li><a href="%s">%s</a></li>`,
+			html.EscapeString(cta.ActionURL), html.EscapeString(cta.Title))
+	}
+	if buttons.Len() > 0 {
+		captionHTML += "<ul>" + buttons.String() + "</ul>"
+	}
 	if captionHTML == "" {
 		return nil
 	}

--- a/pkg/msgconv/igconv/xma_test.go
+++ b/pkg/msgconv/igconv/xma_test.go
@@ -1,0 +1,32 @@
+package igconv
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.mau.fi/mautrix-meta/pkg/instameow/slidetypes"
+)
+
+func TestWrapXMACaptionIncludesCTALinks(t *testing.T) {
+	mc := &MessageConverter{}
+	got := mc.wrapXMACaption(context.Background(), &slidetypes.XMAContent{
+		TitleText: "Card",
+		CTAButtons: []*slidetypes.CTAButton{
+			{Title: "Watch", ActionURL: "https://example.com/watch"},
+			{Title: "No URL"},
+		},
+	})
+	if got == nil {
+		t.Fatal("expected caption")
+	}
+	if !strings.Contains(got.FormattedBody, `href="https://example.com/watch"`) {
+		t.Fatalf("missing link in %s", got.FormattedBody)
+	}
+	if !strings.Contains(got.FormattedBody, "Watch") {
+		t.Fatalf("missing title in %s", got.FormattedBody)
+	}
+	if strings.Contains(got.FormattedBody, "No URL") {
+		t.Fatalf("button without action_url should be skipped, got %s", got.FormattedBody)
+	}
+}


### PR DESCRIPTION
## Summary
- Turn GraphQL XMA `cta_buttons` that already have `action_url` into HTML links in the caption.
- Skip buttons with no URL (postbacks). Those are a different problem: #338.

## Test plan
- [x] `go test ./pkg/msgconv/igconv/`
- [x] Unit test: a CTA with `action_url` becomes an `<a href>`
- [x] Unit test: a CTA with only a title and no URL is omitted
