### PR TITLE
messagix/bloks: allow choosing a different mfa type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	golang.org/x/net v0.58.0
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v3 v3.0.1
-	maunium.net/go/mautrix v0.30.1-0.20260828211758-e9466a65f64c
+	maunium.net/go/mautrix v0.30.1-0.20260831151715-fe59fad51761
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -132,5 +132,5 @@ gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 maunium.net/go/mauflag v1.0.0 h1:YiaRc0tEI3toYtJMRIfjP+jklH45uDHtT80nUamyD4M=
 maunium.net/go/mauflag v1.0.0/go.mod h1:nLivPOpTpHnpzEh8jEdSL9UqO9+/KBJFmNRlwKfkPeA=
-maunium.net/go/mautrix v0.30.1-0.20260828211758-e9466a65f64c h1:AakW6nCwwg1c3/XKK+M+ikCkt6IGTrzlgrZrVHNBHUA=
-maunium.net/go/mautrix v0.30.1-0.20260828211758-e9466a65f64c/go.mod h1:Y02sBiAvfEVqK24bwVGCprmLATRZ7prWel3ZpB413e0=
+maunium.net/go/mautrix v0.30.1-0.20260831151715-fe59fad51761 h1:hCXtZ9QLncjZnVAL0ZJ83sFWb7hQhc0qoBEf7DERYnA=
+maunium.net/go/mautrix v0.30.1-0.20260831151715-fe59fad51761/go.mod h1:Y02sBiAvfEVqK24bwVGCprmLATRZ7prWel3ZpB413e0=

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -332,6 +332,13 @@ func (m *MetaNativeLogin) Wait(ctx context.Context) (*bridgev2.LoginStep, error)
 	return m.proceed(ctx, nil)
 }
 
+func (m *MetaNativeLogin) CancelStep(ctx context.Context) (*bridgev2.LoginStep, error) {
+	if err := m.SavedClient.MessengerLite.CancelLoginStep(ctx); err != nil {
+		return nil, err
+	}
+	return m.proceed(ctx, nil)
+}
+
 func (m *MetaNativeLogin) proceed(ctx context.Context, userInput map[string]string) (*bridgev2.LoginStep, error) {
 	log := zerolog.Ctx(ctx).With().Str("component", "messagix").Logger()
 
@@ -370,3 +377,4 @@ func (m *MetaNativeLogin) proceed(ctx context.Context, userInput map[string]stri
 var _ bridgev2.LoginProcessUserInput = (*MetaNativeLogin)(nil)
 var _ bridgev2.LoginProcessCookies = (*MetaNativeLogin)(nil)
 var _ bridgev2.LoginProcessDisplayAndWait = (*MetaNativeLogin)(nil)
+var _ bridgev2.LoginProcessStepCancel = (*MetaNativeLogin)(nil)

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -339,7 +339,7 @@ type Browser struct {
 	AFADNotification string
 	AFADInterval     time.Duration
 	AFADCallback     func() error
-	AFADCanGoBack    bool
+	MFACanGoBack     bool
 
 	LoginData    string
 	DisplayedURL string
@@ -1447,6 +1447,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 				StepID:       b.stepID("otp_code"),
 				Instructions: instructions,
 				UserInputParams: &bridgev2.LoginUserInputParams{
+					CanCancel: b.MFACanGoBack,
 					Fields: []bridgev2.LoginInputDataField{
 						{
 							ID:   "otp_code",
@@ -1514,6 +1515,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 				StepID:       b.stepID("backup_code"),
 				Instructions: instructions,
 				UserInputParams: &bridgev2.LoginUserInputParams{
+					CanCancel: b.MFACanGoBack,
 					Fields: []bridgev2.LoginInputDataField{
 						{ID: "backup_code", Name: "Backup code", Type: bridgev2.LoginInputFieldType2FACode},
 					},
@@ -1787,7 +1789,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 
 	case StateChooseMFAPage:
 		foundMethods, methodNames, numIgnored := b.profile.findMFAMethods(b.CurrentPage, log)
-		b.AFADCanGoBack = false
+		b.MFACanGoBack = false
 
 		if len(foundMethods) == 0 {
 			if numIgnored == 0 {
@@ -1828,7 +1830,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 		if err != nil {
 			return nil, b.profile.mfaMethodTapError(chosenMethod, err)
 		}
-		b.AFADCanGoBack = len(foundMethods) > 1
+		b.MFACanGoBack = len(foundMethods) > 1
 		if !b.profile.shouldContinueAfterMFAMethod(b.State) {
 			break
 		}
@@ -1856,6 +1858,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 				StepID:       b.stepID("totp"),
 				Instructions: instructions,
 				UserInputParams: &bridgev2.LoginUserInputParams{
+					CanCancel: b.MFACanGoBack,
 					Fields: []bridgev2.LoginInputDataField{
 						{ID: "totp_code", Name: "Six-digit code", Type: bridgev2.LoginInputFieldType2FACode},
 					},
@@ -1957,7 +1960,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			Instructions: b.AFADNotification,
 			DisplayAndWaitParams: &bridgev2.LoginDisplayAndWaitParams{
 				Type:      bridgev2.LoginDisplayTypeNothing,
-				CanCancel: b.AFADCanGoBack,
+				CanCancel: b.MFACanGoBack,
 			},
 		}
 		b.State = StateAFADPageWaiting
@@ -2091,6 +2094,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 				StepID:       b.stepID("sms"),
 				Instructions: instructions,
 				UserInputParams: &bridgev2.LoginUserInputParams{
+					CanCancel: b.MFACanGoBack,
 					Fields: []bridgev2.LoginInputDataField{
 						{ID: "sms_code", Name: "Six-digit code", Type: bridgev2.LoginInputFieldType2FACode},
 					},
@@ -2233,6 +2237,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 				StepID:       b.stepID("whatsapp"),
 				Instructions: instructions,
 				UserInputParams: &bridgev2.LoginUserInputParams{
+					CanCancel: b.MFACanGoBack,
 					Fields: []bridgev2.LoginInputDataField{
 						{ID: "whatsapp_code", Name: "Six-digit code", Type: bridgev2.LoginInputFieldType2FACode},
 					},
@@ -2358,7 +2363,13 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 }
 
 func (b *Browser) CancelLoginStep(ctx context.Context) error {
-	if b.State != StateAFADPageWaiting || !b.AFADCanGoBack {
+	if !b.MFACanGoBack {
+		return fmt.Errorf("current login step cannot be cancelled")
+	}
+	switch b.State {
+	case StateCodeEntryPage, StateBackupCodePage, StateTOTPPage,
+		StateSMSPageAfterSend, StateWhatsAppPageAfterSend, StateAFADPageWaiting:
+	default:
 		return fmt.Errorf("current login step cannot be cancelled")
 	}
 	btn := b.CurrentPage.
@@ -2370,7 +2381,7 @@ func (b *Browser) CancelLoginStep(ctx context.Context) error {
 	if err := btn.TapButton(ctx, b.CurrentPage.Interpreter); err != nil {
 		return fmt.Errorf("tapping try another way button: %w", err)
 	}
-	b.AFADCanGoBack = false
+	b.MFACanGoBack = false
 	return nil
 }
 

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -1974,13 +1974,9 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			if b.AFADCallback == nil {
 				return nil, loginerrors.AFADStopped
 			}
-			timer := time.NewTimer(b.AFADInterval)
 			select {
-			case <-timer.C:
+			case <-time.After(b.AFADInterval):
 			case <-ctx.Done():
-				if !timer.Stop() {
-					<-timer.C
-				}
 				if errors.Is(context.Cause(ctx), bridgev2.ErrLoginStepCancelled) {
 					return nil, bridgev2.ErrLoginStepCancelled
 				}

--- a/pkg/messagix/bloks/selenium.go
+++ b/pkg/messagix/bloks/selenium.go
@@ -339,6 +339,7 @@ type Browser struct {
 	AFADNotification string
 	AFADInterval     time.Duration
 	AFADCallback     func() error
+	AFADCanGoBack    bool
 
 	LoginData    string
 	DisplayedURL string
@@ -1786,6 +1787,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 
 	case StateChooseMFAPage:
 		foundMethods, methodNames, numIgnored := b.profile.findMFAMethods(b.CurrentPage, log)
+		b.AFADCanGoBack = false
 
 		if len(foundMethods) == 0 {
 			if numIgnored == 0 {
@@ -1826,6 +1828,7 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 		if err != nil {
 			return nil, b.profile.mfaMethodTapError(chosenMethod, err)
 		}
+		b.AFADCanGoBack = len(foundMethods) > 1
 		if !b.profile.shouldContinueAfterMFAMethod(b.State) {
 			break
 		}
@@ -1953,7 +1956,8 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			StepID:       b.stepID("afad_wait"),
 			Instructions: b.AFADNotification,
 			DisplayAndWaitParams: &bridgev2.LoginDisplayAndWaitParams{
-				Type: bridgev2.LoginDisplayTypeNothing,
+				Type:      bridgev2.LoginDisplayTypeNothing,
+				CanCancel: b.AFADCanGoBack,
 			},
 		}
 		b.State = StateAFADPageWaiting
@@ -1963,10 +1967,23 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 			if b.AFADCallback == nil {
 				return nil, loginerrors.AFADStopped
 			}
-			time.Sleep(b.AFADInterval)
+			timer := time.NewTimer(b.AFADInterval)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				if errors.Is(context.Cause(ctx), bridgev2.ErrLoginStepCancelled) {
+					return nil, bridgev2.ErrLoginStepCancelled
+				}
+				return nil, fmt.Errorf("login cancelled while waiting for approval: %w", ctx.Err())
+			}
 			err := b.AFADCallback()
 			if err != nil {
-				if ctxErr := ctx.Err(); ctxErr != nil {
+				if errors.Is(context.Cause(ctx), bridgev2.ErrLoginStepCancelled) {
+					return nil, bridgev2.ErrLoginStepCancelled
+				} else if ctxErr := ctx.Err(); ctxErr != nil {
 					return nil, fmt.Errorf("login cancelled while waiting for approval: %w", ctxErr)
 				}
 				return nil, fmt.Errorf("AFAD callback: %w", err)
@@ -2338,6 +2355,23 @@ func (b *Browser) DoLoginStep(ctx context.Context, userInput map[string]string) 
 		b.LastError = ""
 	}
 	return step, nil
+}
+
+func (b *Browser) CancelLoginStep(ctx context.Context) error {
+	if b.State != StateAFADPageWaiting || !b.AFADCanGoBack {
+		return fmt.Errorf("current login step cannot be cancelled")
+	}
+	btn := b.CurrentPage.
+		FindDescendant(FilterByAttribute("bk.data.TextSpan", "text", "Try another way")).
+		FindContainingButton()
+	if btn == nil {
+		return fmt.Errorf("couldn't find try another way button")
+	}
+	if err := btn.TapButton(ctx, b.CurrentPage.Interpreter); err != nil {
+		return fmt.Errorf("tapping try another way button: %w", err)
+	}
+	b.AFADCanGoBack = false
+	return nil
 }
 
 func authenticationConfirmationPageState(page *BloksBundle) BrowserState {

--- a/pkg/messagix/messengerlite.go
+++ b/pkg/messagix/messengerlite.go
@@ -398,3 +398,10 @@ func (m *MessengerLiteMethods) DoLoginSteps(ctx context.Context, userInput map[s
 
 	return nil, m.convertCookies(loginRespPayload.SessionCookies), nil
 }
+
+func (m *MessengerLiteMethods) CancelLoginStep(ctx context.Context) error {
+	if m.browser == nil {
+		return fmt.Errorf("login browser is not initialized")
+	}
+	return m.browser.CancelLoginStep(ctx)
+}


### PR DESCRIPTION
This implements the interface defined in https://github.com/mautrix/go/pull/560 to allow canceling the MFA step after selecting an MFA method, and having that return the user to the MFA selection screen to choose a different method. The option to go back is only presented if there is at least one other supported MFA method to select.

On clients that don't support https://github.com/mautrix/go/pull/560, there is no change in behavior.
