### PR TITLE
messagix/bloks: handle string/bool/nil in i64.Convert

### DIFF
--- a/pkg/messagix/bloks/interp.go
+++ b/pkg/messagix/bloks/interp.go
@@ -1746,8 +1746,27 @@ func (i *Interpreter) Evaluate(ctx context.Context, form *BloksScriptNode) (*Blo
 			return BloksLiteralOf(val), nil
 		case float64:
 			return BloksLiteralOf(int64(val)), nil
+		case string:
+			parsed, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				// Meta sometimes passes float-formatted strings ("3.0").
+				asFloat, floatErr := strconv.ParseFloat(val, 64)
+				if floatErr != nil {
+					return nil, fmt.Errorf("i64.Convert: %q is not an integer: %w", val, err)
+				}
+				return BloksLiteralOf(int64(asFloat)), nil
+			}
+			return BloksLiteralOf(parsed), nil
+		case bool:
+			if val {
+				return BloksLiteralOf(int64(1)), nil
+			}
+			return BloksLiteralOf(int64(0)), nil
+		case nil:
+			return BloksLiteralOf(int64(0)), nil
+		default:
+			return nil, fmt.Errorf("i64.Convert: cannot convert %T to int64", arg.Value())
 		}
-		return nil, fmt.Errorf("can't convert %T to i64", arg.Value())
 	case
 		"bk.action.animated.Start",
 		"bk.action.animated.Build",

--- a/pkg/messagix/bloks/interp_i64_test.go
+++ b/pkg/messagix/bloks/interp_i64_test.go
@@ -1,0 +1,69 @@
+package bloks
+
+import (
+	"context"
+	"testing"
+)
+
+// litNode wraps a literal value in a script node so it can be used as a call argument.
+func litNode(v any) BloksScriptNode {
+	return BloksScriptNode{Content: BloksLiteralOf(v)}
+}
+
+// callNode builds a single-argument function call node.
+func callNode(fn BloksFunctionID, arg any) *BloksScriptNode {
+	return &BloksScriptNode{
+		Content: &BloksScriptFuncall{
+			Function: fn,
+			Args:     []BloksScriptNode{litNode(arg)},
+		},
+	}
+}
+
+// TestI64Convert covers bk.action.i64.Convert, which Meta's two-step verification
+// screen calls during the Messenger Lite login flow. Before this was implemented the
+// interpreter aborted with "unimplemented function bk.action.i64.Convert (1 args)",
+// which broke login immediately after the password was accepted.
+func TestI64Convert(t *testing.T) {
+	i := &Interpreter{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		in   any
+		want int64
+	}{
+		{"int64 passthrough", int64(42), 42},
+		{"float64 truncates", float64(3.9), 3},
+		{"negative float64 truncates toward zero", float64(-3.9), -3},
+		{"numeric string", "1234", 1234},
+		{"negative numeric string", "-7", -7},
+		{"float-formatted string", "3.0", 3},
+		{"bool true", true, 1},
+		{"bool false", false, 0},
+		{"nil is zero", nil, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := i.Evaluate(ctx, callNode("bk.action.i64.Convert", tc.in))
+			if err != nil {
+				t.Fatalf("Evaluate(%#v) returned error: %v", tc.in, err)
+			}
+			gotVal, ok := got.Value().(int64)
+			if !ok {
+				t.Fatalf("Evaluate(%#v) returned %T, want int64", tc.in, got.Value())
+			}
+			if gotVal != tc.want {
+				t.Errorf("Evaluate(%#v) = %d, want %d", tc.in, gotVal, tc.want)
+			}
+		})
+	}
+}
+
+func TestI64ConvertRejectsNonNumericString(t *testing.T) {
+	i := &Interpreter{}
+	if _, err := i.Evaluate(context.Background(), callNode("bk.action.i64.Convert", "abc")); err == nil {
+		t.Fatal("expected an error converting a non-numeric string, got nil")
+	}
+}


### PR DESCRIPTION
Meta's Messenger Lite login flow calls `bk.action.i64.Convert` from the two-step verification (2FA) screen. The interpreter's current implementation only handles `int64` and `float64` arguments, returning `can't convert %T to i64` for anything else. In practice, some steps in the 2FA Bloks flow pass string, bool, or null values into this function, which aborts login right after the password step whenever that happens.

This adds handling for:
- numeric strings, including float-formatted strings like `"3.0"`
- `bool` (`true`/`false` -> `1`/`0`)
- `nil` (-> `0`)

Non-numeric strings still return an error, same as before.

We've been running this patch locally for a stretch as a workaround for logins getting stuck on this exact error during 2FA, and it's resolved it cleanly with no observed regressions. Included a table-driven test covering all the new cases plus the existing numeric passthrough behavior.